### PR TITLE
Encapsulate in a method the way a Transition calculates the tokens it consume. Resolves #12

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/ExclusiveGatewayTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ExclusiveGatewayTransition.php
@@ -16,6 +16,17 @@ class ExclusiveGatewayTransition implements TransitionInterface
     use TransitionTrait;
 
     /**
+     * Initialize the tokens consumed property, the Exclusive Gateway consumes
+     * exactly one token from each transition.
+     *
+     */
+    protected function initExclusiveGatewayTransition()
+    {
+        $this->setTokensConsumedPerTransition(1);
+        $this->setTokensConsumedPerIncoming(1);
+    }
+
+    /**
      * Always true because any token that arrives triggers the gateway
      * outgoing flow transition.
      *

--- a/src/ProcessMaker/Nayra/Bpmn/InclusiveGatewayTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/InclusiveGatewayTransition.php
@@ -2,8 +2,7 @@
 
 namespace ProcessMaker\Nayra\Bpmn;
 
-
-use ProcessMaker\Nayra\Contracts\Bpmn\ConnectionNodeInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\StateInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
@@ -17,6 +16,17 @@ class InclusiveGatewayTransition implements TransitionInterface
 {
 
     use TransitionTrait;
+
+    /**
+     * Initialize the tokens consumed property, the Inclusive Gateway consumes
+     * a token from each incoming Sequence Flow that has a token.
+     *
+     */
+    protected function initExclusiveGatewayTransition()
+    {
+        $this->setTokensConsumedPerTransition(-1);
+        $this->setTokensConsumedPerIncoming(1);
+    }
 
     /**
      * Always true because the conditions are not defined in the gateway, but for each
@@ -54,6 +64,7 @@ class InclusiveGatewayTransition implements TransitionInterface
         $rule2 = $withoutToken->find(function($inFlow) {
                 $paths = $inFlow->origin()->paths(function(Connection $flow) use ($inFlow) {
                     return $flow!==$inFlow
+                        && $flow->origin() instanceof StateInterface
                         && $flow->originState()->getTokens()->count()>0;
                 }, function (Connection $flow) {
                     return $flow->origin()!==$this; //does not visit
@@ -63,6 +74,7 @@ class InclusiveGatewayTransition implements TransitionInterface
         $rule3 = $withToken->find(function($inFlow) {
                 return $inFlow->origin()->paths(function(Connection $flow) use ($inFlow) {
                         return $flow!==$inFlow
+                            && $flow->origin() instanceof StateInterface
                             && $flow->originState()->getTokens()->count()>0;
                     }, function (Connection $flow) {
                         return $flow->origin()!==$this; //does not visit

--- a/src/ProcessMaker/Nayra/Bpmn/ParallelGatewayTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ParallelGatewayTransition.php
@@ -22,7 +22,8 @@ class ParallelGatewayTransition implements TransitionInterface
      */
     protected function initParallelGatewayTransition()
     {
-        $this->setTokensConsumedPerTransition(1);
+        $this->setTokensConsumedPerTransition(-1);
+        $this->setTokensConsumedPerIncoming(1);
     }
 
     /**

--- a/tests/Feature/Engine/ExclusiveGatewayTest.php
+++ b/tests/Feature/Engine/ExclusiveGatewayTest.php
@@ -105,6 +105,52 @@ class ExclusiveGatewayTest extends EngineTestCase
         return $process;
     }
 
+    /**
+     * Parallel diverging Exclusive converging
+     *           ┌─────────┐
+     *        ┌─→│activityA│─┐
+     *  ○─→╱╲─┘  └─────────┘ └─→╱╲  ┌─────────┐
+     *     ╲╱─┐  ┌─────────┐ ┌─→╲╱─→│activityC│─→●
+     *     A  └─→│activityB│─┘  B   └─────────┘
+     *  parallel └─────────┘  exclusive
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\ProcessInterface
+     */
+    private function createParallelDivergingExclusiveConverging()
+    {
+        $process = $this->processRepository->createProcessInstance();
+
+        //elements
+        $start = $this->eventRepository->createStartEventInstance();
+        $gatewayA = $this->gatewayRepository->createParallelGatewayInstance();
+        $activityA = $this->activityRepository->createActivityInstance();
+        $activityB = $this->activityRepository->createActivityInstance();
+        $activityC = $this->activityRepository->createActivityInstance();
+
+        $gatewayB = $this->gatewayRepository->createExclusiveGatewayInstance();
+        $end = $this->eventRepository->createEndEventInstance();
+        $process
+            ->addActivity($activityA)
+            ->addActivity($activityB)
+            ->addActivity($activityC);
+        $process
+            ->addGateway($gatewayA)
+            ->addGateway($gatewayB);
+        $process
+            ->addEvent($start)
+            ->addEvent($end);
+
+        //flows
+        $start->createFlowTo($gatewayA, $this->flowRepository);
+        $gatewayA
+            ->createFlowTo($activityA, $this->flowRepository)
+            ->createFlowTo($activityB, $this->flowRepository);
+        $activityA->createFlowTo($gatewayB, $this->flowRepository);
+        $activityB->createFlowTo($gatewayB, $this->flowRepository);
+        $gatewayB->createFlowTo($activityC, $this->flowRepository);
+        $activityC->createFlowTo($end, $this->flowRepository);
+        return $process;
+    }
 
     /**
      * Tests the basic functionality of the exclusive gateway
@@ -226,6 +272,108 @@ class ExclusiveGatewayTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_COMPLETED,
             ActivityInterface::EVENT_ACTIVITY_CLOSED,
             EventNodeInterface::EVENT_EVENT_TRIGGERED
+        ]);
+    }
+
+    /**
+     * Parallel diverging Exclusive converging
+     *
+     * A process with three tasks, a diverging parallelGateway and a converging exclusiveGateway.
+     * Two of the tasks are executed in parallel and then merged by the exclusiveGateway.
+     * As a result, the task following the exclusiveGateway should be followed twice.
+     */
+    public function testParallelDivergingExclusiveConverging()
+    {
+        //Create a data store with data.
+        $dataStore = $this->dataStoreRepository->createDataStoreInstance();
+
+        //Load the process
+        $process = $this->createParallelDivergingExclusiveConverging();
+        $this->engine->createExecutionInstance($process, $dataStore);
+
+        //Get References
+        $start = $process->getEvents()->item(0);
+        $activityA = $process->getActivities()->item(0);
+        $activityB = $process->getActivities()->item(1);
+        $activityC = $process->getActivities()->item(2);
+
+        //Start the process
+        $start->start();
+
+        $this->engine->runToNextState();
+
+        //Assertion: Verify the triggered engine events. Two activities are activated.
+        $this->assertEvents([
+            EventNodeInterface::EVENT_EVENT_TRIGGERED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_ARRIVES,
+            GatewayInterface::EVENT_GATEWAY_ACTIVATED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_CONSUMED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED
+        ]);
+
+        //Completes the Activity A
+        $tokenA = $activityA->getTokens($dataStore)->item(0);
+        $activityA->complete($tokenA);
+
+        //the run to next state should go false when the max steps is reached.
+        $this->assertFalse($this->engine->runToNextState(1));
+
+        $this->engine->runToNextState();
+
+        //Assertion: Verify the triggered engine events. The activity is closed.
+        $this->assertEvents([
+            ActivityInterface::EVENT_ACTIVITY_COMPLETED,
+            ActivityInterface::EVENT_ACTIVITY_CLOSED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_ARRIVES,
+            GatewayInterface::EVENT_GATEWAY_ACTIVATED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_CONSUMED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+        ]);
+
+        //Completes the Activity B
+        $tokenB = $activityB->getTokens($dataStore)->item(0);
+        $activityB->complete($tokenB);
+        $this->engine->runToNextState();
+
+        //Assertion: Verify the triggered engine events. The activity B is closed.
+        $this->assertEvents([
+            ActivityInterface::EVENT_ACTIVITY_COMPLETED,
+            ActivityInterface::EVENT_ACTIVITY_CLOSED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_ARRIVES,
+            GatewayInterface::EVENT_GATEWAY_ACTIVATED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_CONSUMED,
+            GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+        ]);
+
+        //Assertion: ActivityC has two tokens.
+        $this->assertEquals(2, $activityC->getTokens($dataStore)->count());
+
+        //Completes the Activity C for the first token
+        $tokenC = $activityC->getTokens($dataStore)->item(0);
+        $activityC->complete($tokenC);
+        $this->engine->runToNextState();
+
+        //Completes the Activity C for the next token
+        $tokenC = $activityC->getTokens($dataStore)->item(0);
+        $activityC->complete($tokenC);
+        $this->engine->runToNextState();
+
+        //Assertion: ActivityC has no tokens.
+        $this->assertEquals(0, $activityC->getTokens($dataStore)->count());
+
+        //Assertion: ActivityC was completed and closed per each token, then the end event was triggered twice.
+        $this->assertEvents([
+            ActivityInterface::EVENT_ACTIVITY_COMPLETED,
+            ActivityInterface::EVENT_ACTIVITY_CLOSED,
+            EventNodeInterface::EVENT_EVENT_TRIGGERED,
+            ActivityInterface::EVENT_ACTIVITY_COMPLETED,
+            ActivityInterface::EVENT_ACTIVITY_CLOSED,
+            EventNodeInterface::EVENT_EVENT_TRIGGERED,
         ]);
     }
 }


### PR DESCRIPTION
Encapsulate in a method the way a Transition calculates the tokens it consume.
+ Add betsy test PARALLEL_DIVERGING_EXCLUSIVE_CONVERGING