### PR TITLE
Implement Start Signal Event

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/IntermediateThrowEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/IntermediateThrowEventTrait.php
@@ -64,8 +64,8 @@ trait IntermediateThrowEventTrait
         $incomingPlace=new State($this, GatewayInterface::TOKEN_STATE_INCOMMING);
         $incomingPlace->connectTo($this->transition);
         $incomingPlace->attachEvent(State::EVENT_TOKEN_ARRIVED, function (TokenInterface $token) {
-            $event = $this->getFlows()->item(0)->getSource();
-            $event->collaboration->send($event->getEventDefinitions()->item(0), $token);
+            $collaboration = $this->getEventDefinitions()->item(0)->getPayload()->getMessageFlow()->getCollaboration();
+            $collaboration->send($this->getEventDefinitions()->item(0), $token);
             $this->notifyEvent(IntermediateThrowEventInterface::EVENT_THROW_TOKEN_ARRIVES, $this, $token);
         });
 

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/MessageInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/MessageInterface.php
@@ -48,4 +48,21 @@ interface MessageInterface
      * @return string
      */
     public function getName();
+
+    /**
+     * Sets the message flow to which this message pertains
+     *
+     * @param $messageFlow
+     *
+     * @return mixed
+     */
+    public function setMessageFlow($messageFlow);
+
+
+    /**
+     * Returns the message flow to which this message pertains
+     *
+     * @return mixed
+     */
+    public function getMessageFlow();
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/SignalInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/SignalInterface.php
@@ -34,4 +34,23 @@ interface SignalInterface
      * @param string $value
      */
     public function setName($value);
+
+
+        /**
+     * Sets the message flow to which this message pertains
+     *
+     * @param $messageFlow
+     *
+     * @return mixed
+     */
+    public function setMessageFlow($messageFlow);
+
+
+    /**
+     * Returns the message flow to which this message pertains
+     *
+     * @return mixed
+     */
+    public function getMessageFlow();
+
 }

--- a/tests/Feature/Engine/SignalStartEventTest.php
+++ b/tests/Feature/Engine/SignalStartEventTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature\Engine;
+
+use ProcessMaker\Models\Collaboration;
+use ProcessMaker\Models\Participant;
+use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\EventInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\IntermediateThrowEventInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\ItemDefinitionInterface;
+
+class SignalStartEventTest extends EngineTestCase
+{
+
+    /**
+     * Creates a process with a throwing signal and other with a start signal event
+     *
+     * @return array
+     */
+    public function createSignalStartEventProcesses()
+    {
+        $item = $this->rootElementRepository->createItemDefinitionInstance([
+            'id' => 'item',
+            'isCollection' => true,
+            'itemKind' => ItemDefinitionInterface::ITEM_KIND_INFORMATION,
+            'structure' => 'String'
+        ]);
+
+        $signal = $this->rootElementRepository->createMessageInstance();
+        $signal->setId('SignalA');
+        $signal->setItem($item);
+
+        //Process A
+        $processA = $this->processRepository->createProcessInstance();
+        $startA = $this->eventRepository->createStartEventInstance();
+        $activityA1 = $this->activityRepository->createActivityInstance();
+        $eventA = $this->eventRepository->createIntermediateThrowEventInstance();
+        $signalEventDefA = $this->rootElementRepository->createSignalEventDefinitionInstance();
+        $signalEventDefA->setId("signalEvent1");
+        $signalEventDefA->setPayload($signal);
+        $eventA->getEventDefinitions()->push($signalEventDefA);
+        $activityA2 = $this->activityRepository->createActivityInstance();
+        $endA = $this->eventRepository->createEndEventInstance();
+
+        $startA->createFlowTo($activityA1, $this->flowRepository);
+        $activityA1->createFlowTo($eventA, $this->flowRepository);
+        $eventA->createFlowTo($activityA2, $this->flowRepository);
+        $activityA2->createFlowTo($endA, $this->flowRepository);
+
+        $processA->addActivity($activityA1)
+            ->addActivity($activityA2)
+            ->addEvent($startA)
+            ->addEvent($eventA)
+            ->addEvent($endA);
+
+        //Process B
+        $processB = $this->processRepository->createProcessInstance();
+        $activityB1 = $this->activityRepository->createActivityInstance();
+        $signalEventDefB= $this->rootElementRepository->createSignalEventDefinitionInstance();
+        $signalEventDefB->setPayload($signal);
+
+        $signalStartEventB = $this->eventRepository->createStartEventInstance();
+        $signalStartEventB->getEventDefinitions()->push($signalEventDefB);
+
+        $endB = $this->eventRepository->createEndEventInstance();
+
+        $signalStartEventB->createFlowTo($activityB1, $this->flowRepository);
+        $activityB1->createFlowTo($endB, $this->flowRepository);
+
+        $processB->addActivity($activityB1)
+            ->addEvent($signalStartEventB)
+            ->addEvent($endB);
+
+        return [$processA, $processB];
+
+    }
+
+
+    /**
+     * Tests the start of a process when it receives a signal
+     */
+    public function testSignalStartEvent()
+    {
+        //Create two processes
+        list($processA, $processB) = $this->createSignalStartEventProcesses();
+
+        //Create a collaboration
+        $collaboration = new Collaboration;
+
+        //Add process A as participant of the collaboration
+        $participant = new Participant();
+        $participant->setProcess($processA);
+        $participant->setParticipantMultiplicity(1, 0);
+        $collaboration->getParticipants()->push($participant);
+
+        //Add process B as participant of the collaboration
+        $participant = new Participant();
+        $participant->setProcess($processB);
+        $participant->setParticipantMultiplicity(1, 0);
+        $collaboration->getParticipants()->push($participant);
+
+        //Create message flow from intermediate events A to B
+        $eventA = $processA->getEvents()->item(1);
+        $signalStartEventB = $processB->getEvents()->item(0);
+        $messageFlow = $this->messageFlowRepository->createMessageFlowInstance();
+        $messageFlow->setCollaboration($collaboration);
+        $messageFlow->setSource($eventA);
+        $messageFlow->setTarget($signalStartEventB);
+        $collaboration->addMessageFlow($messageFlow);
+
+        $eventA = $processA->getEvents()->item(1);
+        $eventB = $processB->getEvents()->item(1);
+
+        $dataStoreA = $this->dataStoreRepository->createDataStoreInstance();
+        $dataStoreA->putData('A', '1');
+
+        $dataStoreB = $this->dataStoreRepository->createDataStoreInstance();
+        $dataStoreB->putData('B', '1');
+
+        $instanceA = $this->engine->createExecutionInstance($processA, $dataStoreA);
+        $instanceB = $this->engine->createExecutionInstance($processB, $dataStoreB);
+
+        // we start the process A
+        $startA = $processA->getEvents()->item(0);
+        $activityA1 = $processA->getActivities()->item(0);
+
+        $startA->start();
+        $this->engine->runToNextState();
+
+        //Assertion: The activity must be activated
+        $this->assertEvents([
+            EventInterface::EVENT_EVENT_TRIGGERED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+        ]);
+
+        // we finish the first activity so that a new event should be created in the second process
+        $tokenA = $activityA1->getTokens($instanceA)->item(0);
+        $activityA1->complete($tokenA);
+        $this->engine->runToNextState();
+
+        //Assertion: The process1 activity should be finished and a new instance of the second process must be created
+        $this->assertEvents([
+            ActivityInterface::EVENT_ACTIVITY_COMPLETED,
+            ActivityInterface::EVENT_ACTIVITY_CLOSED,
+            IntermediateThrowEventInterface::EVENT_THROW_TOKEN_ARRIVES,
+
+            //It must trigger the start event of the second process
+            EventInterface::EVENT_EVENT_TRIGGERED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+
+            //Events triggered when the catching event runs
+            IntermediateThrowEventInterface::EVENT_THROW_TOKEN_CONSUMED,
+            IntermediateThrowEventInterface::EVENT_THROW_TOKEN_PASSED,
+
+            //Next activity should be activated in the first process
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+        ]);
+    }
+
+}

--- a/tests/ProcessMaker/Models/Message.php
+++ b/tests/ProcessMaker/Models/Message.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Models;
 
 use ProcessMaker\Nayra\Contracts\Bpmn\ItemDefinitionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\MessageFlowInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\MessageInterface;
 use ProcessMaker\Nayra\Contracts\Repositories\RepositoryFactoryInterface;
 
@@ -27,6 +28,11 @@ class Message implements MessageInterface
      * @var ItemDefinitionInterface $item
      */
     private $item;
+
+    /**
+     * @var MessageFlowInterface $messageFlow
+     */
+    private $messageFlow;
 
     /**
      * @return RepositoryFactoryInterface
@@ -93,5 +99,27 @@ class Message implements MessageInterface
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Sets the message flow to which this signal pertains
+     *
+     * @param $messageFlow
+     *
+     * @return mixed
+     */
+    public function setMessageFlow($messageFlow)
+    {
+        $this->messageFlow = $messageFlow;
+    }
+
+    /**
+     * Returns the message flow to which this signal pertains
+     *
+     * @return mixed
+     */
+    public function getMessageFlow()
+    {
+        return $this->messageFlow;
     }
 }

--- a/tests/ProcessMaker/Models/MessageFlow.php
+++ b/tests/ProcessMaker/Models/MessageFlow.php
@@ -57,6 +57,7 @@ class MessageFlow implements MessageFlowInterface
     public function setTarget(CatchEventInterface $target)
     {
         $eventDef = $this->getSource()->getEventDefinitions()->item(0);
+        $eventDef->getPayload()->setMessageFlow($this);
         $this->getCollaboration()->unsubscribe($target, $eventDef->getId());
         $this->getCollaboration()->subscribe($target, $eventDef->getId());
         $this->target = $target;

--- a/tests/ProcessMaker/Models/Signal.php
+++ b/tests/ProcessMaker/Models/Signal.php
@@ -54,4 +54,26 @@ class Signal implements SignalInterface
     {
         $this->name = $value;
     }
+
+    /**
+     * Sets the message flow to which this signal pertains
+     *
+     * @param $messageFlow
+     *
+     * @return mixed
+     */
+    public function setMessageFlow($messageFlow)
+    {
+        $this->messageFlow = $messageFlow;
+    }
+
+    /**
+     * Returns the message flow to which this signal pertains
+     *
+     * @return mixed
+     */
+    public function getMessageFlow()
+    {
+        return $this->messageFlow;
+    }
 }


### PR DESCRIPTION
* Start signal event and tests implemented.
* It was removed the need to set the collaboration for every event, now it is got from the FlowMessage.
* To implement the point above, the message interface was modified to add getters and setters to the signal interface.