### PR TITLE
Implement Start Timer Event. Resolves #25

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/IntermediateCatchEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/IntermediateCatchEventTrait.php
@@ -11,9 +11,9 @@ use ProcessMaker\Nayra\Contracts\Bpmn\IntermediateCatchEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\StateInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
+use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 use ProcessMaker\Nayra\Contracts\Repositories\RepositoryFactoryInterface;
-use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 
 /**
  * End event behavior's implementation.

--- a/src/ProcessMaker/Nayra/Bpmn/IntermediateCatchEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/IntermediateCatchEventTrait.php
@@ -13,6 +13,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 use ProcessMaker\Nayra\Contracts\Repositories\RepositoryFactoryInterface;
+use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 
 /**
  * End event behavior's implementation.
@@ -118,6 +119,11 @@ trait IntermediateCatchEventTrait
 
         // with a new token in the trigger place, the event catch element will be fired
         $this->triggerPlace->addNewToken($instance);
+        return $this;
+    }
+
+    public function registerCatchEvents(EngineInterface $engine)
+    {
         return $this;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/IntermediateCatchEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/IntermediateCatchEventTrait.php
@@ -122,6 +122,13 @@ trait IntermediateCatchEventTrait
         return $this;
     }
 
+    /**
+     * Register catch events.
+     *
+     * @param EngineInterface $engine
+     *
+     * @return $this
+     */
     public function registerCatchEvents(EngineInterface $engine)
     {
         return $this;

--- a/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
@@ -9,6 +9,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 use ProcessMaker\Nayra\Contracts\Repositories\RepositoryFactoryInterface;
+use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 
 /**
  * Implementation of the behavior of a start event.
@@ -105,5 +106,19 @@ trait StartEventTrait
             $index < 0 ?: $this->triggerPlace[$index]->addNewToken($instance);
         }
         return $this;
+    }
+
+    /**
+     * Register catch events.
+     *
+     * @param EngineInterface $engine
+     */
+    public function registerCatchEvents(EngineInterface $engine)
+    {
+        foreach ($this->getEventDefinitions() as $eventDefinition) {
+            if (is_callable([$eventDefinition, 'registerCatchEvents'])) {
+                $eventDefinition->registerCatchEvents($engine, $this);
+            }
+        }
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
@@ -7,9 +7,9 @@ use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
+use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 use ProcessMaker\Nayra\Contracts\Repositories\RepositoryFactoryInterface;
-use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 
 /**
  * Implementation of the behavior of a start event.

--- a/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
@@ -112,6 +112,8 @@ trait StartEventTrait
      * Register catch events.
      *
      * @param EngineInterface $engine
+     *
+     * @return $this
      */
     public function registerCatchEvents(EngineInterface $engine)
     {
@@ -120,5 +122,6 @@ trait StartEventTrait
                 $eventDefinition->registerCatchEvents($engine, $this);
             }
         }
+        return $this;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/TimerEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/TimerEventDefinition.php
@@ -44,6 +44,8 @@ class TimerEventDefinition implements TimerEventDefinitionInterface
      * Get the duration expression for the timer event definition.
      *
      * @return \ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface
+     *
+     * @codeCoverageIgnore Until intermediate timer event implementation
      */
     public function getTimeDuration()
     {
@@ -74,7 +76,6 @@ class TimerEventDefinition implements TimerEventDefinitionInterface
     {
         $this->scheduleTimeDate($engine, $element);
         $this->scheduleTimeCycle($engine, $element);
-        $this->scheduleTimeDuration($engine, $element);
     }
 
     /**
@@ -124,7 +125,7 @@ class TimerEventDefinition implements TimerEventDefinitionInterface
     {
         $expression = $this->getTimeCycle();
         if ($expression) {
-            $cycle = $expression();
+            $cycle = $expression($this->getDataFrom($engine, $token));
             $engine->getDispatcher()->dispatch(
                 JobManagerInterface::EVENT_SCHEDULE_CYCLE,
                 $cycle,
@@ -141,12 +142,14 @@ class TimerEventDefinition implements TimerEventDefinitionInterface
      * @param EngineInterface $engine
      * @param FlowElementInterface $element
      * @param TokenInterface $token
+     *
+     * @codeCoverageIgnore Until intermediate timer event implementation
      */
     private function scheduleTimeDuration(EngineInterface $engine, FlowElementInterface $element, TokenInterface $token = null)
     {
         $expression = $this->getTimeDuration();
         if ($expression) {
-            $duration = $expression();
+            $duration = $expression($this->getDataFrom($engine, $token));
             $engine->getDispatcher()->dispatch(
                 JobManagerInterface::EVENT_SCHEDULE_DURATION,
                 $duration,

--- a/src/ProcessMaker/Nayra/Bpmn/TimerEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/TimerEventDefinition.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TimerEventDefinitionInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+/**
+ * MessageEventDefinition class
+ *
+ */
+class TimerEventDefinition implements TimerEventDefinitionInterface
+{
+    use BaseTrait;
+
+
+    /**
+     * Get the date expression for the timer event definition.
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface
+     */
+    public function getTimeDate()
+    {
+        return $this->getProperty(self::BPMN_PROPERTY_TIME_DATE);
+    }
+
+    /**
+     * Get the cycle expression for the timer event definition.
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface
+     */
+    public function getTimeCycle()
+    {
+        return $this->getProperty(self::BPMN_PROPERTY_TIME_CYCLE);
+    }
+
+    /**
+     * Get the duration expression for the timer event definition.
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface
+     */
+    public function getTimeDuration()
+    {
+        return $this->getProperty(self::BPMN_PROPERTY_TIME_DURATION);
+    }
+
+    /**
+     * Assert the event definition rule for trigger the event.
+     *
+     * @param EventDefinitionInterface $event
+     * @param FlowNodeInterface $target
+     * @param ExecutionInstanceInterface $instance
+     *
+     * @return boolean
+     */
+    public function assertsRule(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null)
+    {
+        return true;
+    }
+}

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/CatchEventInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/CatchEventInterface.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Nayra\Contracts\Bpmn;
 
+use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
+
 /**
  * CatchEvent interface.
  *
@@ -23,4 +25,6 @@ interface CatchEventInterface extends EventInterface
      * @return \ProcessMaker\Nayra\Engine\ExecutionInstance[]
      */
     public function getTargetInstances(EventDefinitionInterface $message, TokenInterface $token);
+
+    public function registerCatchEvents(EngineInterface $engine);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/CatchEventInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/CatchEventInterface.php
@@ -26,5 +26,12 @@ interface CatchEventInterface extends EventInterface
      */
     public function getTargetInstances(EventDefinitionInterface $message, TokenInterface $token);
 
+    /**
+     * Register catch events.
+     *
+     * @param EngineInterface $engine
+     *
+     * @return $this
+     */
     public function registerCatchEvents(EngineInterface $engine);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/TimerEventDefinitionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/TimerEventDefinitionInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ProcessMaker\Nayra\Contracts\Bpmn;
+
+/**
+ * TimerEventDefinition interface.
+ *
+ * @package ProcessMaker\Nayra\Contracts\Bpmn
+ */
+interface TimerEventDefinitionInterface extends EventDefinitionInterface
+{
+    const BPMN_PROPERTY_TIME_DATE = 'timeDate';
+    const BPMN_PROPERTY_TIME_CYCLE = 'timeCycle';
+    const BPMN_PROPERTY_TIME_DURATION = 'timeDuration';
+
+    const EVENT_THROW_EVENT_DEFINITION = 'ThrowTimerEvent';
+    const EVENT_CATCH_EVENT_DEFINITION = 'CatchTimerEvent';
+
+    /**
+     * Get the date expression for the timer event definition.
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface
+     */
+    public function getTimeDate();
+
+    /**
+     * Get the cycle expression for the timer event definition.
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface
+     */
+    public function getTimeCycle();
+
+    /**
+     * Get the duration expression for the timer event definition.
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface
+     */
+    public function getTimeDuration();
+}

--- a/src/ProcessMaker/Nayra/Contracts/Engine/EngineInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Engine/EngineInterface.php
@@ -59,6 +59,15 @@ interface EngineInterface
     public function step();
 
     /**
+     * Load a process into the engine
+     *
+     * @param ProcessInterface $process
+     *
+     * @return $this
+     */
+    public function loadProcess(ProcessInterface $process);
+
+    /**
      * Create an execution instance of a process.
      *
      * @param ProcessInterface $process

--- a/src/ProcessMaker/Nayra/Contracts/Engine/JobManagerInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Engine/JobManagerInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ProcessMaker\Nayra\Contracts\Engine;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\EntityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TimerEventDefinitionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\FlowElementInterface;
+
+/**
+ * Job manager required for scheduling timer events.
+ *
+ */
+interface JobManagerInterface
+{
+    const EVENT_SCHEDULE_DATE = 'ScheduleDate';
+    const EVENT_SCHEDULE_CYCLE = 'ScheduleCycle';
+    const EVENT_SCHEDULE_DURATION = 'ScheduleDuration';
+
+    /**
+     * Schedule a job for a specific date and time for the given BPMN element,
+     * event definition and an optional Token object
+     *
+     * @param string $datetime in ISO-8601 format
+     * @param TimerEventDefinitionInterface $eventDefinition
+     * @param EntityInterface $element
+     * @param TokenInterface $token
+     *
+     * @return $this
+     */
+    public function scheduleDate($datetime, TimerEventDefinitionInterface $eventDefinition,
+                                 FlowElementInterface $element, TokenInterface $token = null);
+
+    /**
+     * Schedule a job for a specific cycle for the given BPMN element, event definition
+     * and an optional Token object
+     *
+     * @param string $cycle in ISO-8601 format
+     * @param TimerEventDefinitionInterface $eventDefinition
+     * @param EntityInterface $element
+     * @param TokenInterface $token
+     */
+    public function scheduleCycle($cycle, TimerEventDefinitionInterface $eventDefinition, FlowElementInterface $element,
+                                  TokenInterface $token = null);
+
+    /**
+     * Schedule a job execution after a time duration for the given BPMN element,
+     * event definition and an optional Token object
+     *
+     * @param string $duration in ISO-8601 format
+     * @param TimerEventDefinitionInterface $eventDefinition
+     * @param EntityInterface $element
+     * @param TokenInterface $token
+     */
+    public function scheduleDuration($duration, TimerEventDefinitionInterface $eventDefinition,
+                                     FlowElementInterface $element, TokenInterface $token = null);
+}

--- a/src/ProcessMaker/Nayra/Contracts/Engine/JobManagerInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Engine/JobManagerInterface.php
@@ -2,10 +2,10 @@
 
 namespace ProcessMaker\Nayra\Contracts\Engine;
 
-use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EntityInterface;
-use ProcessMaker\Nayra\Contracts\Bpmn\TimerEventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowElementInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TimerEventDefinitionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 
 /**
  * Job manager required for scheduling timer events.

--- a/src/ProcessMaker/Nayra/Contracts/Engine/JobManagerInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Engine/JobManagerInterface.php
@@ -10,6 +10,8 @@ use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 /**
  * Job manager required for scheduling timer events.
  *
+ * This interface also defines the different types of schedules that a timer
+ * event could use.
  */
 interface JobManagerInterface
 {

--- a/tests/Feature/Engine/EngineTestCase.php
+++ b/tests/Feature/Engine/EngineTestCase.php
@@ -139,8 +139,8 @@ class EngineTestCase extends TestCase
         $this->jobManager->expects($this->any())
             ->method('scheduleDate')
             ->will($this->returnCallback(function($date, TimerEventDefinitionInterface $timerDefinition, FlowElementInterface $element, TokenInterface $token = null) {
-                echo "SCHEDULE $date\n";
                     $this->jobs[] = [
+                        'repeat' => false,
                         'timer' => $date,
                         'eventDefinition' => $timerDefinition,
                         'element' => $element,
@@ -151,8 +151,8 @@ class EngineTestCase extends TestCase
         $this->jobManager->expects($this->any())
             ->method('scheduleCycle')
             ->will($this->returnCallback(function($cycle, TimerEventDefinitionInterface $timerDefinition, FlowElementInterface $element, TokenInterface $token = null) {
-                echo "SCHEDULE $cycle\n";
                     $this->jobs[] = [
+                        'repeat' => true,
                         'timer' => $cycle,
                         'eventDefinition' => $timerDefinition,
                         'element' => $element,
@@ -163,8 +163,8 @@ class EngineTestCase extends TestCase
         $this->jobManager->expects($this->any())
             ->method('scheduleDuration')
             ->will($this->returnCallback(function($duration, TimerEventDefinitionInterface $timerDefinition, FlowElementInterface $element, TokenInterface $token = null) {
-                echo "SCHEDULE $duration\n";
                     $this->jobs[] = [
+                        'repeat' => false,
                         'timer' => $duration,
                         'eventDefinition' => $timerDefinition,
                         'element' => $element,
@@ -283,6 +283,9 @@ class EngineTestCase extends TestCase
     protected function dispatchJob()
     {
         $job = array_shift($this->jobs);
+        if ($job && $job['repeat']) {
+            $this->jobs[] = $job;
+        }
         $instance = $job['token'] ? $job['token']->getInstance() : null;
         return $job ? $job['element']->execute($job['eventDefinition'], $instance) : null;
     }

--- a/tests/Feature/Engine/SignalEndEventTest.php
+++ b/tests/Feature/Engine/SignalEndEventTest.php
@@ -6,6 +6,7 @@ use ProcessMaker\Models\Collaboration;
 use ProcessMaker\Models\DataStoreCollection;
 use ProcessMaker\Models\Participant;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\EndEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\IntermediateCatchEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\IntermediateThrowEventInterface;
@@ -161,6 +162,7 @@ class SignalEndEventTest extends EngineTestCase
             IntermediateCatchEventInterface::EVENT_CATCH_TOKEN_ARRIVES
             ]);
 
+        //Start the process B
         $startB->start();
         $this->engine->runToNextState();
 
@@ -170,6 +172,7 @@ class SignalEndEventTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
 
+        //Complete the activity
         $tokenB = $activityB1->getTokens($instanceB)->item(0);
         $activityB1->complete($tokenB);
         $this->engine->runToNextState();
@@ -180,7 +183,7 @@ class SignalEndEventTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_CLOSED,
 
             // the throw token of the end is sent
-            IntermediateThrowEventInterface::EVENT_THROW_TOKEN_ARRIVES,
+            EndEventInterface::EVENT_THROW_TOKEN_ARRIVES,
             SignalEventDefinitionInterface::EVENT_THROW_EVENT_DEFINITION,
 
             // the Process A catching message is activated

--- a/tests/Feature/Engine/StartTimerEventTest.php
+++ b/tests/Feature/Engine/StartTimerEventTest.php
@@ -7,10 +7,10 @@ use DateInterval;
 use ProcessMaker\Repositories\BpmnFileRepository;
 
 /**
- * Timer Event tests
+ * Start Timer Event tests
  *
  */
-class TimerEventTest extends EngineTestCase
+class StartTimerEventTest extends EngineTestCase
 {
 
     /**
@@ -27,9 +27,10 @@ class TimerEventTest extends EngineTestCase
         //Load a process from a bpmn repository by Id
         $process = $bpmnRepository->loadBpmElementById('Process');
         $startEvent = $bpmnRepository->loadBpmElementById('_9');
+        $this->engine->loadProcess($process);
 
         //Assertion: The jobs manager receive a scheduling request to trigger the start event time cycle specified in the process
-        $this->assertScheduledCyclicTimer('2018-05-01T14:30:33', $startEvent);
+        $this->assertScheduledDateTimer('2018-05-01T14:30:00', $startEvent);
 
         //Force to dispatch the requersted job
         $this->dispatchJob();
@@ -74,17 +75,21 @@ class TimerEventTest extends EngineTestCase
         $bpmnRepository->setEngine($this->engine);
         $bpmnRepository->load(__DIR__ . '/files/Timer_StartEvent_TimeDateExpression.bpmn');
 
-        //Load a process from a bpmn repository by Id
-        $process = $bpmnRepository->loadBpmElementById('Process');
-        $startEvent = $bpmnRepository->loadBpmElementById('_9');
-
-        $this->engine->loadProcess($process);
-
-        //Assertion: The jobs manager receive a scheduling request to trigger the start event at the date time calculated by the expression
+        //Create a default environment data
+        $environmentData = $bpmnRepository->getDataStoreRepository()->createDataStoreInstance();
+        $this->engine->setDataStore($environmentData);
         $date = new DateTime;
         $date->setTime(23, 59, 59);
         $calculatedDate = $date->format(DateTime::ISO8601);
-        $this->assertScheduledCyclicTimer($calculatedDate, $startEvent);
+        $environmentData->putData('calculatedDate', $calculatedDate);
+
+        //Load a process from a bpmn repository by Id
+        $process = $bpmnRepository->loadBpmElementById('Process');
+        $startEvent = $bpmnRepository->loadBpmElementById('_9');
+        $this->engine->loadProcess($process);
+
+        //Assertion: The jobs manager receive a scheduling request to trigger the start event at the date time calculated by the expression
+        $this->assertScheduledDateTimer($calculatedDate, $startEvent);
 
         //Assertion: The calculated value should conform to the ISO-8601 format for date and time representations.
         $value = $this->jobs[0]['timer'];
@@ -106,13 +111,19 @@ class TimerEventTest extends EngineTestCase
         $bpmnRepository->setEngine($this->engine);
         $bpmnRepository->load(__DIR__ . '/files/Timer_StartEvent_TimeCycleExpression.bpmn');
 
+        //Create a default environment data
+        $environmentData = $bpmnRepository->getDataStoreRepository()->createDataStoreInstance();
+        $this->engine->setDataStore($environmentData);
+        $everyMinute = '1M';
+        $calculatedCycle = 'R/PT' . $everyMinute;
+        $environmentData->putData('calculatedCycle', $calculatedCycle);
+
         //Load a process from a bpmn repository by Id
         $process = $bpmnRepository->loadBpmElementById('Process');
         $startEvent = $bpmnRepository->loadBpmElementById('_9');
 
         //Assertion: The jobs manager receive a scheduling request to trigger the start event time cycle specified in the process
-        $everyMinute = '1M';
-        $calculatedCycle = 'R/PT' . $everyMinute;
+        var_dump($this->jobs);
         $this->assertScheduledCyclicTimer($calculatedCycle, $startEvent);
 
         //Assertion: The calculated value should conform to the ISO-8601 format for date and time representations.

--- a/tests/Feature/Engine/StartTimerEventTest.php
+++ b/tests/Feature/Engine/StartTimerEventTest.php
@@ -117,8 +117,11 @@ class StartTimerEventTest extends EngineTestCase
         //Create a default environment data
         $environmentData = $bpmnRepository->getDataStoreRepository()->createDataStoreInstance();
         $this->engine->setDataStore($environmentData);
+
+        //Calculate a iso8601 string for a cyclic timer of 1 minute from 2018-05-01 at 00:00 UTC
         $everyMinute = '1M';
-        $calculatedCycle = 'R4/2018-05-01T00:00:00Z/PT' . $everyMinute;
+        $fromDate = '2018-05-01T00:00:00Z';
+        $calculatedCycle = 'R4/' . $fromDate . '/PT' . $everyMinute;
         $environmentData->putData('calculatedCycle', $calculatedCycle);
 
         //Load a process from a bpmn repository by Id

--- a/tests/Feature/Engine/TerminateEventTest.php
+++ b/tests/Feature/Engine/TerminateEventTest.php
@@ -18,10 +18,10 @@ class TerminateEventTest extends EngineTestCase
 {
 
     /**
-     * Test conditional start event
+     * Test terminate end event
      *
      */
-    public function testConditionalStartEvent()
+    public function testTerminateEndEvent()
     {
         //Load a BpmnFile Repository
         $bpmnRepository = new BpmnFileRepository();

--- a/tests/Feature/Engine/TimerEventTest.php
+++ b/tests/Feature/Engine/TimerEventTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Engine;
 
+use DateTime;
+use DateInterval;
 use ProcessMaker\Repositories\BpmnFileRepository;
 
 /**
@@ -27,7 +29,7 @@ class TimerEventTest extends EngineTestCase
         $startEvent = $bpmnRepository->loadBpmElementById('_9');
 
         //Assertion: The jobs manager receive a scheduling request to trigger the start event time cycle specified in the process
-        $this->assertScheduledCyclicTimer('R/PT1M', $startEvent);
+        $this->assertScheduledCyclicTimer('2018-05-01T14:30:33', $startEvent);
 
         //Force to dispatch the requersted job
         $this->dispatchJob();
@@ -38,7 +40,7 @@ class TimerEventTest extends EngineTestCase
      * Test the start timer event with a time cycle specified in ISO8601 format.
      *
      */
-    public function testTerminateEndEvent()
+    public function testStartTimerEventWithTimeCycle()
     {
         //Load a BpmnFile Repository
         $bpmnRepository = new BpmnFileRepository();
@@ -59,5 +61,90 @@ class TimerEventTest extends EngineTestCase
         //Force to dispatch the requersted job
         $this->dispatchJob();
         $this->assertEquals(2, $process->getInstances()->count());
+    }
+
+    /**
+     * Test the start timer event with a date time specified by an expression.
+     *
+     */
+    public function testStartTimerEventWithTimeDateExpression()
+    {
+        //Load a BpmnFile Repository
+        $bpmnRepository = new BpmnFileRepository();
+        $bpmnRepository->setEngine($this->engine);
+        $bpmnRepository->load(__DIR__ . '/files/Timer_StartEvent_TimeDateExpression.bpmn');
+
+        //Load a process from a bpmn repository by Id
+        $process = $bpmnRepository->loadBpmElementById('Process');
+        $startEvent = $bpmnRepository->loadBpmElementById('_9');
+
+        $this->engine->loadProcess($process);
+
+        //Assertion: The jobs manager receive a scheduling request to trigger the start event at the date time calculated by the expression
+        $date = new DateTime;
+        $date->setTime(23, 59, 59);
+        $calculatedDate = $date->format(DateTime::ISO8601);
+        $this->assertScheduledCyclicTimer($calculatedDate, $startEvent);
+
+        //Assertion: The calculated value should conform to the ISO-8601 format for date and time representations.
+        $value = $this->jobs[0]['timer'];
+        $this->assertValidDate($value);
+
+        //Force to dispatch the requersted job
+        $this->dispatchJob();
+        $this->assertEquals(1, $process->getInstances()->count());
+    }
+
+    /**
+     * Test the start timer event with a time cycle specified by an expression.
+     *
+     */
+    public function testStartTimerEventWithTimeCycleExpression()
+    {
+        //Load a BpmnFile Repository
+        $bpmnRepository = new BpmnFileRepository();
+        $bpmnRepository->setEngine($this->engine);
+        $bpmnRepository->load(__DIR__ . '/files/Timer_StartEvent_TimeCycleExpression.bpmn');
+
+        //Load a process from a bpmn repository by Id
+        $process = $bpmnRepository->loadBpmElementById('Process');
+        $startEvent = $bpmnRepository->loadBpmElementById('_9');
+
+        //Assertion: The jobs manager receive a scheduling request to trigger the start event time cycle specified in the process
+        $everyMinute = '1M';
+        $calculatedCycle = 'R/PT' . $everyMinute;
+        $this->assertScheduledCyclicTimer($calculatedCycle, $startEvent);
+
+        //Assertion: The calculated value should conform to the ISO-8601 format for date and time representations.
+        $value = $this->jobs[0]['timer'];
+        $this->assertValidInterval($value);
+
+        //Force to dispatch the requersted job
+        $this->dispatchJob();
+        $this->assertEquals(1, $process->getInstances()->count());
+
+        //Force to dispatch the requersted job
+        $this->dispatchJob();
+        $this->assertEquals(2, $process->getInstances()->count());
+    }
+
+    /**
+     * Validate if the string has a valid ISO8601 date time representation
+     *
+     * @param string $date
+     */
+    private function assertValidDate($date)
+    {
+        $this->assertTrue(new DateTime($date) !== false);
+    }
+
+    /**
+     * Validate if the string has a valid ISO8601 interval (cycle or duration) representation
+     *
+     * @param string $interval
+     */
+    private function assertValidInterval($interval)
+    {
+        $this->assertTrue(new DateInterval($interval) !== false);
     }
 }

--- a/tests/Feature/Engine/TimerEventTest.php
+++ b/tests/Feature/Engine/TimerEventTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Engine;
+
+use ProcessMaker\Repositories\BpmnFileRepository;
+
+/**
+ * Test a terminate event.
+ *
+ */
+class TimerEventTest extends EngineTestCase
+{
+
+    /**
+     * Test terminate end event
+     *
+     */
+    public function testTerminateEndEvent()
+    {
+        //Load a BpmnFile Repository
+        $bpmnRepository = new BpmnFileRepository();
+        $bpmnRepository->setEngine($this->engine);
+        $bpmnRepository->load(__DIR__ . '/files/Timer_StartEvent_TimeCycle.bpmn');
+
+        //Load a process from a bpmn repository by Id
+        $process = $bpmnRepository->loadBpmElementById('Process');
+        $startEvent = $bpmnRepository->loadBpmElementById('_9');
+
+        //Assertion: The jobs manager receive a scheduling request to trigger the start event time cycle specified in the process
+
+        //Foce to dispatch the requersted job
+        $this->dispatchJob();
+
+        //Foce to dispatch the requersted job
+        $this->dispatchJob();
+    }
+}

--- a/tests/Feature/Engine/TimerEventTest.php
+++ b/tests/Feature/Engine/TimerEventTest.php
@@ -5,14 +5,37 @@ namespace Tests\Feature\Engine;
 use ProcessMaker\Repositories\BpmnFileRepository;
 
 /**
- * Test a terminate event.
+ * Timer Event tests
  *
  */
 class TimerEventTest extends EngineTestCase
 {
 
     /**
-     * Test terminate end event
+     * Test the start timer event with a date time specified in ISO8601 format.
+     *
+     */
+    public function testStartTimerEventWithTimeDate()
+    {
+        //Load a BpmnFile Repository
+        $bpmnRepository = new BpmnFileRepository();
+        $bpmnRepository->setEngine($this->engine);
+        $bpmnRepository->load(__DIR__ . '/files/Timer_StartEvent_TimeDate.bpmn');
+
+        //Load a process from a bpmn repository by Id
+        $process = $bpmnRepository->loadBpmElementById('Process');
+        $startEvent = $bpmnRepository->loadBpmElementById('_9');
+
+        //Assertion: The jobs manager receive a scheduling request to trigger the start event time cycle specified in the process
+        $this->assertScheduledCyclicTimer('R/PT1M', $startEvent);
+
+        //Force to dispatch the requersted job
+        $this->dispatchJob();
+        $this->assertEquals(1, $process->getInstances()->count());
+    }
+
+    /**
+     * Test the start timer event with a time cycle specified in ISO8601 format.
      *
      */
     public function testTerminateEndEvent()
@@ -27,11 +50,14 @@ class TimerEventTest extends EngineTestCase
         $startEvent = $bpmnRepository->loadBpmElementById('_9');
 
         //Assertion: The jobs manager receive a scheduling request to trigger the start event time cycle specified in the process
+        $this->assertScheduledCyclicTimer('R/PT1M', $startEvent);
 
-        //Foce to dispatch the requersted job
+        //Force to dispatch the requersted job
         $this->dispatchJob();
+        $this->assertEquals(1, $process->getInstances()->count());
 
-        //Foce to dispatch the requersted job
+        //Force to dispatch the requersted job
         $this->dispatchJob();
+        $this->assertEquals(2, $process->getInstances()->count());
     }
 }

--- a/tests/Feature/Engine/files/Timer_StartEvent_TimeCycle.bpmn
+++ b/tests/Feature/Engine/files/Timer_StartEvent_TimeCycle.bpmn
@@ -15,7 +15,7 @@
       <outgoing>_11</outgoing>
       <outputSet/>
       <timerEventDefinition id="_9_ED_1">
-        <timeCycle><![CDATA[R/PT1M]]></timeCycle>
+        <timeCycle><![CDATA[R4/2018-05-01T00:00:00Z/PT1M]]></timeCycle>
       </timerEventDefinition>
     </startEvent>
     <endEvent id="_12" name="End Event">
@@ -45,17 +45,17 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge bpmnElement="_13" id="Yaoqiang-_13">
-        <di:waypoint x="286.409090909091" y="163.95454545454547"/>
-        <di:waypoint x="339.415548823932" y="163.95454545454547"/>
+        <di:waypoint x="285.9545454545455" y="163.95454545454547"/>
+        <di:waypoint x="339.9610033693865" y="163.95454545454547"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="18.96" width="6.0" x="309.91" y="154.48"/>
+          <dc:Bounds height="18.96" width="6.0" x="309.96" y="154.48"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="_11" id="Yaoqiang-_11">
-        <di:waypoint x="121.40263299424998" y="163.95454545454547"/>
-        <di:waypoint x="201.409090909091" y="163.95454545454547"/>
+        <di:waypoint x="120.94808753970449" y="163.95454545454547"/>
+        <di:waypoint x="200.9545454545455" y="163.95454545454547"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="18.96" width="6.0" x="158.41" y="154.48"/>
+          <dc:Bounds height="18.96" width="6.0" x="157.95" y="154.48"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/tests/Feature/Engine/files/Timer_StartEvent_TimeCycle.bpmn
+++ b/tests/Feature/Engine/files/Timer_StartEvent_TimeCycle.bpmn
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1526992813193" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1526992813193" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <process id="Process" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:description/>
+      <yaoqiang:pageFormat height="841.8897637795276" imageableHeight="831.8897637795276" imageableWidth="588.1102362204724" imageableX="5.0" imageableY="5.0" orientation="0" width="598.1102362204724"/>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <scriptTask completionQuantity="1" id="_10" isForCompensation="false" name="Script Task" startQuantity="1">
+      <incoming>_11</incoming>
+      <outgoing>_13</outgoing>
+    </scriptTask>
+    <sequenceFlow id="_11" sourceRef="_9" targetRef="_10"/>
+    <startEvent id="_9" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_11</outgoing>
+      <outputSet/>
+      <timerEventDefinition id="_9_ED_1">
+        <timeCycle><![CDATA[R/PT1M]]></timeCycle>
+      </timerEventDefinition>
+    </startEvent>
+    <endEvent id="_12" name="End Event">
+      <incoming>_13</incoming>
+      <inputSet/>
+    </endEvent>
+    <sequenceFlow id="_13" sourceRef="_10" targetRef="_12"/>
+  </process>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-Process" name="Untitled Diagram" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="Process">
+      <bpmndi:BPMNShape bpmnElement="_10" id="Yaoqiang-_10">
+        <dc:Bounds height="55.0" width="85.0" x="201.31818181818187" y="136.45454545454547"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="65.0" x="211.32" y="156.48"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_9" id="Yaoqiang-_9">
+        <dc:Bounds height="32.0" width="32.0" x="88.95454545454552" y="147.95454545454547"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="63.0" x="73.45" y="188.48"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_12" id="Yaoqiang-_12">
+        <dc:Bounds height="32.0" width="32.0" x="339.50000000000006" y="147.95454545454547"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="58.0" x="326.5" y="188.48"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_13" id="Yaoqiang-_13">
+        <di:waypoint x="286.409090909091" y="163.95454545454547"/>
+        <di:waypoint x="339.415548823932" y="163.95454545454547"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="6.0" x="309.91" y="154.48"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_11" id="Yaoqiang-_11">
+        <di:waypoint x="121.40263299424998" y="163.95454545454547"/>
+        <di:waypoint x="201.409090909091" y="163.95454545454547"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="6.0" x="158.41" y="154.48"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/Feature/Engine/files/Timer_StartEvent_TimeCycleExpression.bpmn
+++ b/tests/Feature/Engine/files/Timer_StartEvent_TimeCycleExpression.bpmn
@@ -15,7 +15,7 @@
       <outgoing>_11</outgoing>
       <outputSet/>
       <timerEventDefinition id="_9_ED_1">
-        <timeCycle><![CDATA[data.calculatedCycle]]></timeCycle>
+        <timeCycle><![CDATA[$data['calculatedCycle']]]></timeCycle>
       </timerEventDefinition>
     </startEvent>
     <endEvent id="_12" name="End Event">
@@ -45,17 +45,17 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge bpmnElement="_13" id="Yaoqiang-_13">
-        <di:waypoint x="285.9545454545455" y="163.95454545454547"/>
-        <di:waypoint x="339.9610033693865" y="163.95454545454547"/>
+        <di:waypoint x="286.409090909091" y="163.95454545454547"/>
+        <di:waypoint x="339.415548823932" y="163.95454545454547"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="18.96" width="6.0" x="309.96" y="154.48"/>
+          <dc:Bounds height="18.96" width="6.0" x="309.91" y="154.48"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="_11" id="Yaoqiang-_11">
-        <di:waypoint x="120.94808753970449" y="163.95454545454547"/>
-        <di:waypoint x="200.9545454545455" y="163.95454545454547"/>
+        <di:waypoint x="121.40263299424998" y="163.95454545454547"/>
+        <di:waypoint x="201.409090909091" y="163.95454545454547"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="18.96" width="6.0" x="157.95" y="154.48"/>
+          <dc:Bounds height="18.96" width="6.0" x="158.41" y="154.48"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/tests/Feature/Engine/files/Timer_StartEvent_TimeCycleExpression.bpmn
+++ b/tests/Feature/Engine/files/Timer_StartEvent_TimeCycleExpression.bpmn
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1526992813193" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1526992813193" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1526992813193" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1527096227788" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1527096227788" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1527096227788" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
   <process id="Process" isClosed="false" isExecutable="true" processType="None">
     <extensionElements>
       <yaoqiang:description/>
@@ -15,7 +15,7 @@
       <outgoing>_11</outgoing>
       <outputSet/>
       <timerEventDefinition id="_9_ED_1">
-        <timeCycle><![CDATA[R/PT1M]]></timeCycle>
+        <timeCycle><![CDATA[data.calculatedCycle]]></timeCycle>
       </timerEventDefinition>
     </startEvent>
     <endEvent id="_12" name="End Event">
@@ -45,17 +45,17 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge bpmnElement="_13" id="Yaoqiang-_13">
-        <di:waypoint x="286.409090909091" y="163.95454545454547"/>
-        <di:waypoint x="339.415548823932" y="163.95454545454547"/>
+        <di:waypoint x="285.9545454545455" y="163.95454545454547"/>
+        <di:waypoint x="339.9610033693865" y="163.95454545454547"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="18.96" width="6.0" x="309.91" y="154.48"/>
+          <dc:Bounds height="18.96" width="6.0" x="309.96" y="154.48"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="_11" id="Yaoqiang-_11">
-        <di:waypoint x="121.40263299424998" y="163.95454545454547"/>
-        <di:waypoint x="201.409090909091" y="163.95454545454547"/>
+        <di:waypoint x="120.94808753970449" y="163.95454545454547"/>
+        <di:waypoint x="200.9545454545455" y="163.95454545454547"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="18.96" width="6.0" x="158.41" y="154.48"/>
+          <dc:Bounds height="18.96" width="6.0" x="157.95" y="154.48"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/tests/Feature/Engine/files/Timer_StartEvent_TimeDate.bpmn
+++ b/tests/Feature/Engine/files/Timer_StartEvent_TimeDate.bpmn
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1526992813193" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1526992813193" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1526992813193" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1527096041313" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1527096041313" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1527096041313" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
   <process id="Process" isClosed="false" isExecutable="true" processType="None">
     <extensionElements>
       <yaoqiang:description/>
@@ -15,7 +15,7 @@
       <outgoing>_11</outgoing>
       <outputSet/>
       <timerEventDefinition id="_9_ED_1">
-        <timeCycle><![CDATA[R/PT1M]]></timeCycle>
+        <timeDate><![CDATA[2018-05-01T14:30:00]]></timeDate>
       </timerEventDefinition>
     </startEvent>
     <endEvent id="_12" name="End Event">

--- a/tests/Feature/Engine/files/Timer_StartEvent_TimeDateExpression.bpmn
+++ b/tests/Feature/Engine/files/Timer_StartEvent_TimeDateExpression.bpmn
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1526992813193" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1526992813193" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1526992813193" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1527096300424" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1527096300424" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1527096300424" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
   <process id="Process" isClosed="false" isExecutable="true" processType="None">
     <extensionElements>
       <yaoqiang:description/>
@@ -15,7 +15,7 @@
       <outgoing>_11</outgoing>
       <outputSet/>
       <timerEventDefinition id="_9_ED_1">
-        <timeCycle><![CDATA[R/PT1M]]></timeCycle>
+        <timeDate><![CDATA[$data["calculatedDate"]]]></timeDate>
       </timerEventDefinition>
     </startEvent>
     <endEvent id="_12" name="End Event">
@@ -33,9 +33,9 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="_9" id="Yaoqiang-_9">
-        <dc:Bounds height="32.0" width="32.0" x="88.95454545454552" y="147.95454545454547"/>
+        <dc:Bounds height="32.0" width="32.0" x="88.95454545454552" y="142.95454545454547"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="18.96" width="63.0" x="73.45" y="188.48"/>
+          <dc:Bounds height="18.96" width="63.0" x="73.45" y="183.48"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="_12" id="Yaoqiang-_12">
@@ -52,10 +52,10 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="_11" id="Yaoqiang-_11">
-        <di:waypoint x="121.40263299424998" y="163.95454545454547"/>
+        <di:waypoint x="121.40263299424998" y="158.95454545454547"/>
         <di:waypoint x="201.409090909091" y="163.95454545454547"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="18.96" width="6.0" x="158.41" y="154.48"/>
+          <dc:Bounds height="18.96" width="6.0" x="158.14" y="152.25"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/tests/ProcessMaker/Models/FormalExpression.php
+++ b/tests/ProcessMaker/Models/FormalExpression.php
@@ -2,12 +2,12 @@
 
 namespace ProcessMaker\Models;
 
+use DateInterval;
 use DatePeriod;
 use DateTime;
 use Exception;
 use ProcessMaker\Nayra\Bpmn\BaseTrait;
 use ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface;
-
 
 /**
  * FormalExpression implementation
@@ -56,7 +56,7 @@ class FormalExpression implements FormalExpressionInterface
     public function __invoke($data)
     {
         $expression = $this->getProperty(FormalExpressionInterface::BPMN_PROPERTY_BODY);
-        if ($this->isDateExpression() || $this->isIntervalExpression()) {
+        if ($this->isDateExpression() || $this->isCycleExpression() || $this->isDurationExpression()) {
             return $expression;
         }
         $test = new TestBetsy($data, $expression);
@@ -80,15 +80,31 @@ class FormalExpression implements FormalExpressionInterface
     }
 
     /**
-     * Verify if the expression is an interval.
+     * Verify if the expression is a cycle.
      *
      * @return boolean
      */
-    private function isIntervalExpression()
+    private function isCycleExpression()
     {
         $expression = $this->getProperty(FormalExpressionInterface::BPMN_PROPERTY_BODY);
         try {
             $interval = new DatePeriod($expression);
+        } catch (Exception $e) {
+            return false;
+        }
+        return $interval !== false;
+    }
+
+    /**
+     * Verify if the expression is a duration.
+     *
+     * @return boolean
+     */
+    private function isDurationExpression()
+    {
+        $expression = $this->getProperty(FormalExpressionInterface::BPMN_PROPERTY_BODY);
+        try {
+            $interval = new DateInterval($expression);
         } catch (Exception $e) {
             return false;
         }

--- a/tests/ProcessMaker/Models/RootElementRepository.php
+++ b/tests/ProcessMaker/Models/RootElementRepository.php
@@ -9,6 +9,7 @@ use ProcessMaker\Nayra\Bpmn\MessageEventDefinition;
 use ProcessMaker\Nayra\Bpmn\RepositoryTrait;
 use ProcessMaker\Nayra\Bpmn\SignalEventDefinition;
 use ProcessMaker\Nayra\Bpmn\TerminateEventDefinition;
+use ProcessMaker\Nayra\Bpmn\TimerEventDefinition;
 use ProcessMaker\Nayra\Contracts\Repositories\RootElementRepositoryInterface;
 
 /**
@@ -137,5 +138,15 @@ class RootElementRepository implements RootElementRepositoryInterface
     public function createErrorInstance()
     {
         return new Error();
+    }
+
+    /**
+     * Create a TimerEventDefinition.
+     *
+     * @return TimerEventDefinition
+     */
+    public function createTimerEventDefinitionInstance()
+    {
+        return new TimerEventDefinition();
     }
 }

--- a/tests/ProcessMaker/Models/TestBetsy.php
+++ b/tests/ProcessMaker/Models/TestBetsy.php
@@ -9,14 +9,35 @@ namespace ProcessMaker\Models;
 class TestBetsy
 {
     public $data;
+    private $code;
 
-    public function __construct($data)
+    public function __construct($data, $expression)
     {
         $this->data = $data;
+        $tokens = token_get_all('<?php ' . $expression);
+        $tokens[0] = '';
+        $code = '';
+        foreach ($tokens as $token) {
+            if (is_array($token) && $token[1] === 'test') {
+                $code .= '$' . $token[1];
+            } elseif ($token === '.') {
+                $code .= '->';
+            } else {
+                $code .= is_array($token) ? $token[1] : $token;
+            }
+        }
+        $this->code = $code;
     }
 
     public function contains($name)
     {
         return isset($this->data[$name]);
+    }
+
+    public function call()
+    {
+        $test = $this;
+        $data = $this->data;
+        return eval('return ' . $this->code . ';');
     }
 }

--- a/tests/ProcessMaker/Repositories/BpmnFileElement.php
+++ b/tests/ProcessMaker/Repositories/BpmnFileElement.php
@@ -21,6 +21,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\GatewayInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\MessageFlowInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ParticipantInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\StartEventInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TimerEventDefinitionInterface;
 
 /**
  * Description of BpmnFileElement
@@ -175,6 +176,36 @@ class BpmnFileElement extends DOMElement
                 [
                     MessageFlowInterface::BPMN_PROPERTY_SOURCE => ['1', [BpmnFileRepository::BPMN, MessageFlowInterface::BPMN_PROPERTY_SOURCE_REF]],
                     MessageFlowInterface::BPMN_PROPERTY_TARGET => ['1', [BpmnFileRepository::BPMN, MessageFlowInterface::BPMN_PROPERTY_TARGET_REF]],
+                ]
+            ],
+            'timerEventDefinition' => [
+                'getRootElementRepository',
+                'createTimerEventDefinitionInstance',
+                [
+                    TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_DATE => ['1', [BpmnFileRepository::BPMN, TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_DATE]],
+                    TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_CYCLE => ['1', [BpmnFileRepository::BPMN, TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_CYCLE]],
+                    TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_DURATION => ['1', [BpmnFileRepository::BPMN, TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_DURATION]],
+                ]
+            ],
+            TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_DATE => [
+                'getRootElementRepository',
+                'createFormalExpressionInstance',
+                [
+                    FormalExpressionInterface::BPMN_PROPERTY_BODY => ['1', self::DOM_ELEMENT_BODY],
+                ]
+            ],
+            TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_CYCLE => [
+                'getRootElementRepository',
+                'createFormalExpressionInstance',
+                [
+                    FormalExpressionInterface::BPMN_PROPERTY_BODY => ['1', self::DOM_ELEMENT_BODY],
+                ]
+            ],
+            TimerEventDefinitionInterface::BPMN_PROPERTY_TIME_DURATION => [
+                'getRootElementRepository',
+                'createFormalExpressionInstance',
+                [
+                    FormalExpressionInterface::BPMN_PROPERTY_BODY => ['1', self::DOM_ELEMENT_BODY],
                 ]
             ],
         ]


### PR DESCRIPTION
This pull request implements TimerEventDefinitions in Start Events.
![image](https://user-images.githubusercontent.com/8028650/40452513-0f85faf4-5eb0-11e8-945c-575e4b389fb2.png)
It implements:

- Start a process by a ISO8601 specific date time expression
- Start a process cyclically by a ISO8601 specific cyclic expression
- Start a process by a calculable expression 
- Start a process cyclically by a calculable expression
![image](https://user-images.githubusercontent.com/8028650/40452738-e6d0e898-5eb0-11e8-96e1-28b45cd62bda.png)
![image](https://user-images.githubusercontent.com/8028650/40452756-f5dd403e-5eb0-11e8-8213-9741d925b227.png)
