### PR TITLE
Add execute method for Event Definition Elements. Resolves #115

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/Models/ConditionalEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/ConditionalEventDefinition.php
@@ -6,8 +6,13 @@ use ProcessMaker\Nayra\Bpmn\BaseTrait;
 use ProcessMaker\Nayra\Contracts\Bpmn\ConditionalEventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
+/**
+ * ConditionalEventDefinition class
+ *
+ */
 class ConditionalEventDefinition implements ConditionalEventDefinitionInterface
 {
 
@@ -18,7 +23,7 @@ class ConditionalEventDefinition implements ConditionalEventDefinitionInterface
      *
      * @param EventDefinitionInterface $event
      * @param FlowNodeInterface $target
-     * @param ExecutionInstanceInterface $instance
+     * @param ExecutionInstanceInterface|null $instance
      *
      * @return boolean
      */
@@ -39,5 +44,20 @@ class ConditionalEventDefinition implements ConditionalEventDefinitionInterface
     public function getCondition()
     {
         return $this->getProperty(ConditionalEventDefinitionInterface::BPMN_PROPERTY_CONDITION);
+    }
+
+    /**
+     * Implement the event definition behavior when an event is triggered.
+     *
+     * @param EventDefinitionInterface $event
+     * @param FlowNodeInterface $target
+     * @param ExecutionInstanceInterface|null $instance
+     * @param TokenInterface|null $token
+     *
+     * @return $this
+     */
+    public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
+    {
+        return $this;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/ErrorEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/ErrorEventDefinition.php
@@ -7,8 +7,13 @@ use ProcessMaker\Nayra\Contracts\Bpmn\ErrorEventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
+/**
+ * ErrorEventDefinition class
+ *
+ */
 class ErrorEventDefinition implements ErrorEventDefinitionInterface
 {
 
@@ -19,7 +24,7 @@ class ErrorEventDefinition implements ErrorEventDefinitionInterface
      *
      * @param EventDefinitionInterface $event
      * @param FlowNodeInterface $target
-     * @param ExecutionInstanceInterface $instance
+     * @param ExecutionInstanceInterface|null $instance
      *
      * @return boolean
      */
@@ -39,10 +44,11 @@ class ErrorEventDefinition implements ErrorEventDefinitionInterface
     }
 
     /**
-     * Get the error of the event definition.
+     * Set the error of the event definition.
      *
      * @param ErrorInterface $error
-     * @return self
+     *
+     * @return $this
      */
     public function setError(ErrorInterface $error)
     {
@@ -58,5 +64,20 @@ class ErrorEventDefinition implements ErrorEventDefinitionInterface
     public function getPayload()
     {
         return $this->getError();
+    }
+
+    /**
+     * Implement the event definition behavior when an event is triggered.
+     *
+     * @param EventDefinitionInterface $event
+     * @param FlowNodeInterface $target
+     * @param ExecutionInstanceInterface|null $instance
+     * @param TokenInterface|null $token
+     *
+     * @return $this
+     */
+    public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
+    {
+        return $this;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
@@ -8,6 +8,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\MessageEventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\MessageInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\OperationInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
 /**
@@ -73,5 +74,20 @@ class MessageEventDefinition implements MessageEventDefinitionInterface
     public function assertsRule(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null)
     {
         return true;
+    }
+
+    /**
+     * Implement the event definition behavior when an event is triggered.
+     *
+     * @param EventDefinitionInterface $event
+     * @param FlowNodeInterface $target
+     * @param ExecutionInstanceInterface|null $instance
+     * @param TokenInterface|null $token
+     *
+     * @return $this
+     */
+    public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
+    {
+        return $this;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/SignalEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/SignalEventDefinition.php
@@ -7,8 +7,13 @@ use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\SignalEventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\SignalInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
+/**
+ * SignalEventDefinition class
+ *
+ */
 class SignalEventDefinition implements SignalEventDefinitionInterface
 {
 
@@ -36,11 +41,14 @@ class SignalEventDefinition implements SignalEventDefinitionInterface
     /**
      * Sets the element id
      *
-     * @param $value
+     * @param mixed $value
+     *
+     * @return $this
      */
     public function setId($value)
     {
         $this->id = $value;
+        return $this;
     }
 
     /**
@@ -67,12 +75,27 @@ class SignalEventDefinition implements SignalEventDefinitionInterface
      *
      * @param EventDefinitionInterface $event
      * @param FlowNodeInterface $target
-     * @param ExecutionInstanceInterface $instance
+     * @param ExecutionInstanceInterface|null $instance
      *
      * @return boolean
      */
     public function assertsRule(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null)
     {
         return true;
+    }
+
+    /**
+     * Implement the event definition behavior when an event is triggered.
+     *
+     * @param EventDefinitionInterface $event
+     * @param FlowNodeInterface $target
+     * @param ExecutionInstanceInterface|null $instance
+     * @param TokenInterface|null $token
+     *
+     * @return $this
+     */
+    public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
+    {
+        return $this;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/TerminateEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/TerminateEventDefinition.php
@@ -6,8 +6,13 @@ use ProcessMaker\Nayra\Bpmn\BaseTrait;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TerminateEventDefinitionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
+/**
+ * TerminateEventDefinition class
+ *
+ */
 class TerminateEventDefinition implements TerminateEventDefinitionInterface
 {
 
@@ -18,12 +23,27 @@ class TerminateEventDefinition implements TerminateEventDefinitionInterface
      *
      * @param EventDefinitionInterface $event
      * @param FlowNodeInterface $target
-     * @param ExecutionInstanceInterface $instance
+     * @param ExecutionInstanceInterface|null $instance
      *
      * @return boolean
      */
     public function assertsRule(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null)
     {
         return true;
+    }
+
+    /**
+     * Implement the event definition behavior when an event is triggered.
+     *
+     * @param EventDefinitionInterface $event
+     * @param FlowNodeInterface $target
+     * @param ExecutionInstanceInterface|null $instance
+     * @param TokenInterface|null $token
+     *
+     * @return $this
+     */
+    public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
+    {
+        return $this;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/TimerEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/TimerEventDefinition.php
@@ -207,5 +207,19 @@ class TimerEventDefinition implements TimerEventDefinitionInterface
     {
         $this->setProperty(self::BPMN_PROPERTY_TIME_DURATION, $timeExpression);
     }
-}
 
+    /**
+     * Implement the event definition behavior when an event is triggered.
+     *
+     * @param EventDefinitionInterface $event
+     * @param FlowNodeInterface $target
+     * @param ExecutionInstanceInterface|null $instance
+     * @param TokenInterface|null $token
+     *
+     * @return $this
+     */
+    public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
+    {
+        return $this;
+    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
@@ -3,10 +3,10 @@
 namespace ProcessMaker\Nayra\Bpmn;
 
 use ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface;
-use ProcessMaker\Nayra\Contracts\Bpmn\DataStoreInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
@@ -93,10 +93,11 @@ trait StartEventTrait
      *
      * @param EventDefinitionInterface $event
      * @param ExecutionInstanceInterface|null $instance
+     * @param TokenInterface|null $token
      *
      * @return $this
      */
-    public function execute(EventDefinitionInterface $event, ExecutionInstanceInterface $instance = null)
+    public function execute(EventDefinitionInterface $event, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
     {
         $start = $this->getEventDefinitions()->count() === 0;
         $index = -1;
@@ -111,6 +112,10 @@ trait StartEventTrait
                 $process = $this->getOwnerProcess();
                 $dataStorage = $process->getRepository()->createDataStore();
                 $instance = $process->getEngine()->createExecutionInstance($process, $dataStorage);
+            }
+            //Execute the behavior of the EventDefinition
+            foreach ($this->getEventDefinitions() as $index => $eventDefinition) {
+                $eventDefinition->execute($event, $this, $instance, $token);
             }
             $this->start();
             // with a new token in the trigger place, the event catch element will be fired

--- a/src/ProcessMaker/Nayra/Bpmn/TerminateTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/TerminateTransition.php
@@ -27,11 +27,12 @@ class TerminateTransition implements TransitionInterface
     /**
      * Condition required to terminate the token.
      *
-     * @param TokenInterface $token
+     * @param TokenInterface|null $token
+     * @param ExecutionInstanceInterface|null $executionInstance
      *
      * @return bool
      */
-    public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance)
+    public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
     {
         return $this->eventDefinition->assertsRule($this->eventDefinition, $this->owner, $executionInstance);
     }
@@ -48,6 +49,7 @@ class TerminateTransition implements TransitionInterface
         $tokens = [];
         foreach($executionInstance->getTokens() as $token) {
             if ($this->assertCondition($token, $executionInstance)) {
+                $this->eventDefinition->execute($this->eventDefinition, $this->owner, $executionInstance, $token);
                 $tokens[]=$token;
             }
         }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/ErrorEventDefinitionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/ErrorEventDefinitionInterface.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Nayra\Contracts\Bpmn;
 
+use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
+
 /**
  * ErrorEventDefinition interface.
  *
@@ -28,4 +30,13 @@ interface ErrorEventDefinitionInterface extends EventDefinitionInterface
      * @return ErrorInterface
      */
     public function getPayload();
+
+    /**
+     * Set the error of the event definition.
+     *
+     * @param ErrorInterface $error
+     *
+     * @return $this
+     */
+    public function setError(ErrorInterface $error);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/EventDefinitionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/EventDefinitionInterface.php
@@ -23,7 +23,7 @@ interface EventDefinitionInterface extends EntityInterface
     /**
      * Sets the element id
      *
-     * @param $value
+     * @param mixed $value
      */
     public function setId($value);
 
@@ -32,9 +32,21 @@ interface EventDefinitionInterface extends EntityInterface
      *
      * @param EventDefinitionInterface $event
      * @param FlowNodeInterface $target
-     * @param ExecutionInstanceInterface $instance
+     * @param ExecutionInstanceInterface|null $instance
      *
      * @return boolean
      */
     public function assertsRule(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null);
+
+    /**
+     * Implement the event definition behavior when an event is triggered.
+     *
+     * @param EventDefinitionInterface $event
+     * @param FlowNodeInterface $target
+     * @param ExecutionInstanceInterface|null $instance
+     * @param TokenInterface|null $token
+     *
+     * @return $this
+     */
+    public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/TransitionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/TransitionInterface.php
@@ -18,6 +18,8 @@ interface TransitionInterface extends ConnectionNodeInterface
     /**
      * Execute a transition.
      *
+     * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface $executionInstance
+     *
      * @return bool
      */
     public function execute(ExecutionInstanceInterface $executionInstance);
@@ -25,7 +27,7 @@ interface TransitionInterface extends ConnectionNodeInterface
     /**
      * Evaluates if the transition condition evaluates to true using the data of the execution instance
      *
-     * @param TokenInterface $token
+     * @param TokenInterface|null $token
      * @param ExecutionInstanceInterface $executionInstance
      * @return mixed
      */


### PR DESCRIPTION
Add the public function execute to the EventDefinitionInterface and all the classes that implements it.

```
    /**
     * Implement the event definition behavior when an event is triggered.
     *
     * @param EventDefinitionInterface $event
     * @param FlowNodeInterface $target
     * @param ExecutionInstanceInterface|null $instance
     * @param TokenInterface|null $token
     *
     * @return $this
     */
    public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null);
```