### PR TITLE
Accept null engine when load bpmn

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/ProcessTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ProcessTrait.php
@@ -419,11 +419,11 @@ trait ProcessTrait
     /**
      * Set the engine that controls the elements.
      *
-     * @param EngineInterface $engine
+     * @param EngineInterface|null $engine
      *
      * @return EngineInterface
      */
-    public function setEngine(EngineInterface $engine)
+    public function setEngine(EngineInterface $engine = null)
     {
         $this->engine = $engine;
         return $this;

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/CallableElementInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/CallableElementInterface.php
@@ -15,11 +15,11 @@ interface CallableElementInterface extends EntityInterface
     /**
      * Set the engine that controls the elements.
      *
-     * @param EngineInterface $engine
+     * @param EngineInterface|null $engine
      *
      * @return EngineInterface
      */
-    public function setEngine(EngineInterface $engine);
+    public function setEngine(EngineInterface $engine = null);
 
     /**
      * Get the engine that controls the elements.

--- a/src/ProcessMaker/Nayra/Contracts/Repositories/StorageInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Repositories/StorageInterface.php
@@ -37,11 +37,11 @@ interface StorageInterface
     /**
      * Set the document engine.
      *
-     * @param \ProcessMaker\Nayra\Contracts\Engine\EngineInterface $engine
+     * @param \ProcessMaker\Nayra\Contracts\Engine\EngineInterface|null $engine
      *
      * @return $this
      */
-    public function setEngine(EngineInterface $engine);
+    public function setEngine(EngineInterface $engine = null);
 
     /**
      * Get the BPMN elements mapping.

--- a/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
+++ b/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
@@ -1088,11 +1088,11 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
     }
 
     /**
-     * @param \ProcessMaker\Nayra\Contracts\Engine\EngineInterface $engine
+     * @param \ProcessMaker\Nayra\Contracts\Engine\EngineInterface|null $engine
      *
      * @return $this
      */
-    public function setEngine(EngineInterface $engine)
+    public function setEngine(EngineInterface $engine = null)
     {
         $this->engine = $engine;
         return $this;


### PR DESCRIPTION
This change enables to load a BPMN definitions without an Engine instance.
