### PR TITLE
Remove tests and others from distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.circleci export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs export-ignore
+/check_coverage.php export-ignore
+/phpunit.xml export-ignore
+/docs export-ignore
+/tests export-ignore


### PR DESCRIPTION
Lets not ship all tests, test bpmn files, xsd, ci settings and other development files in a distribution build.