### PR TITLE
Skip MultiInstance Activity if Input is empty

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/DataInputTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/DataInputTransition.php
@@ -5,13 +5,12 @@ namespace ProcessMaker\Nayra\Bpmn;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface;
-use ProcessMaker\Nayra\Contracts\Bpmn\StateInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
 /**
- * Transition rule that always pass the token.
+ * Transition to check if the activity is a loop not yet completed or a single instance
  *
  * @package ProcessMaker\Nayra\Bpmn
  */
@@ -29,6 +28,10 @@ class DataInputTransition implements TransitionInterface
      */
     public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
     {
+        $loop = $this->getOwner()->getLoopCharacteristics();
+        if ($loop && $loop->isExecutable()) {
+            return !$loop->isLoopCompleted($executionInstance, $token);
+        }
         return true;
     }
 

--- a/src/ProcessMaker/Nayra/Bpmn/EmptyDataInputTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/EmptyDataInputTransition.php
@@ -29,10 +29,8 @@ class EmptyDataInputTransition implements TransitionInterface
     public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
     {
         $loop = $this->getOwner()->getLoopCharacteristics();
-        if ($loop && $loop->isExecutable()) {
-            return $loop->isLoopCompleted($executionInstance, $token);
-        }
-        return false;
+        $isLoopCompleted = $loop && $loop->isExecutable() && $loop->isLoopCompleted($executionInstance, $token);
+        return $isLoopCompleted;
     }
 
     /**

--- a/src/ProcessMaker/Nayra/Bpmn/EmptyDataInputTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/EmptyDataInputTransition.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+/**
+ * Transition to check if the activity is a loop and the loop is completed
+ *
+ * @package ProcessMaker\Nayra\Bpmn
+ */
+class EmptyDataInputTransition implements TransitionInterface
+{
+    use TransitionTrait;
+
+    /**
+     * Condition required to transit the element.
+     *
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface|null $token
+     * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface|null $executionInstance
+     *
+     * @return bool
+     */
+    public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
+    {
+        $loop = $this->getOwner()->getLoopCharacteristics();
+        if ($loop && $loop->isExecutable()) {
+            return $loop->isLoopCompleted($executionInstance, $token);
+        }
+        return false;
+    }
+
+    /**
+     * Get transition owner element
+     *
+     * @return ActivityInterface
+     */
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+
+//    /**
+//     * Activate the next state.
+//     *
+//     * @param \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface $flow
+//     * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface $instance
+//     * @param \ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface $consumeTokens
+//     * @param array $properties
+//     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface|null $source
+//     *
+//     * @return TokenInterface
+//     */
+//    protected function activateNextState(ConnectionInterface $flow, ExecutionInstanceInterface $instance, CollectionInterface $consumeTokens, array $properties = [], TransitionInterface $source = null)
+//    {
+//        $nextState = $flow->targetState();
+//        $loop = $this->getOwner()->getLoopCharacteristics();
+//        if ($loop && $loop->isExecutable()) {
+//            $loop->iterateNextState($nextState, $instance, $consumeTokens, $properties, $source);
+//        } else {
+//            $nextState->addNewToken($instance, $properties, $source);
+//        }
+//    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/LoopCharacteristicsTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/LoopCharacteristicsTrait.php
@@ -72,6 +72,9 @@ trait LoopCharacteristicsTrait
     public function getLoopInstanceProperty(TokenInterface $token, $key, $defaultValue = null)
     {
         $loopCharacteristics = $token->getProperty(LoopCharacteristicsInterface::BPMN_LOOP_INSTANCE_PROPERTY, []);
+        if (!isset($loopCharacteristics['sourceToken'])) {
+            return $defaultValue;
+        }
         $outerInstance = $loopCharacteristics['sourceToken'];
         $ds = $token->getInstance()->getDataStore();
         $data = $ds->getData(LoopCharacteristicsInterface::BPMN_LOOP_INSTANCE_PROPERTY, []);

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
@@ -214,7 +214,10 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
      */
     public function isLoopCompleted(ExecutionInstanceInterface $instance, TokenInterface $token)
     {
-        $numberOfInstances = $this->getLoopInstanceProperty($token, 'numberOfInstances', 0);
+        $numberOfInstances = $this->getLoopInstanceProperty($token, 'numberOfInstances', null);
+        if ($numberOfInstances === null) {
+            $numberOfInstances = $this->calcNumberOfInstances($instance);
+        }
         $completed = $this->getLoopInstanceProperty($token, 'numberOfCompletedInstances', 0);
         return $completed >= $numberOfInstances;
     }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
@@ -123,10 +123,7 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
                 $loopCounter = $this->getLoopInstanceProperty($token, 'loopCounter', 0);
                 // Token loopCounter
                 $tokenLoopCounter = $token->getProperty('data', [])['loopCounter'] ?? 0;
-                if ($loopCounter!==$tokenLoopCounter) {
-                    continue;
-                }
-                if ($loopCounter < $numberOfInstances) {
+                if ($loopCounter === $tokenLoopCounter && $loopCounter < $numberOfInstances) {
                     $loopCounter++;
                     $numberOfActiveInstances = 1;
                     $this->createInstance(

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
@@ -119,7 +119,13 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
             // The number of instances are calculated once, when entering the activity.
             $numberOfInstances = $this->calcNumberOfInstances($instance);
             if ($this->getIsSequential()) {
+                // LoopInstance Counter
                 $loopCounter = $this->getLoopInstanceProperty($token, 'loopCounter', 0);
+                // Token loopCounter
+                $tokenLoopCounter = $token->getProperty('data', [])['loopCounter'] ?? 0;
+                if ($loopCounter!==$tokenLoopCounter) {
+                    continue;
+                }
                 if ($loopCounter < $numberOfInstances) {
                     $loopCounter++;
                     $numberOfActiveInstances = 1;

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
@@ -181,10 +181,11 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
             $properties['data'] = array_merge($properties['data'], (array) $item);
         }
         $properties['data']['loopCounter'] = $loopCounter;
-        $newToken = $nextState->addNewToken($instance, $properties, $source);
+        $newToken = $nextState->createToken($instance, $properties, $source);
         $this->setLoopInstanceProperty($newToken, 'numberOfActiveInstances', $numberOfActiveInstances);
         $this->setLoopInstanceProperty($newToken, 'numberOfInstances', $numberOfInstances);
         $this->setLoopInstanceProperty($newToken, 'loopCounter', $loopCounter);
+        $nextState->addToken($instance, $newToken, false, $source);
     }
 
     /**

--- a/src/ProcessMaker/Nayra/Bpmn/StateTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/StateTrait.php
@@ -104,6 +104,27 @@ trait StateTrait
     }
 
     /**
+     * Create token for the current state.
+     *
+     * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface|null $instance
+     * @param array $properties
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface|null $source
+     *
+     * @return TokenInterface
+     */
+    public function createToken(ExecutionInstanceInterface $instance = null, array $properties = [])
+    {
+        $token = $this->getRepository()->getTokenRepository()->createTokenInstance();
+        $token->setOwner($this);
+        $token->setProperties($properties);
+        $token->setOwner($this);
+        $token->setInstance($instance);
+        $this->getName() ? $token->setStatus($this->getName()) : '';
+        $token->setIndex($this->getIndex());
+        return $token;
+    }
+
+    /**
      * Add a new token instance to the state.
      *
      * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface $instance

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/ActivityInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/ActivityInterface.php
@@ -17,7 +17,7 @@ interface ActivityInterface extends FlowNodeInterface
     const EVENT_ACTIVITY_EXCEPTION = 'ActivityException';
     const EVENT_ACTIVITY_CANCELLED = 'ActivityCancelled';
     const EVENT_ACTIVITY_CLOSED = 'ActivityClosed';
-    const EVENT_EVENT_TRIGGERED = 'EventTriggered';
+    const EVENT_ACTIVITY_SKIPPED = 'ActivitySkipped';
 
     /**
      * Properties and composed elements
@@ -32,6 +32,7 @@ interface ActivityInterface extends FlowNodeInterface
     const TOKEN_STATE_FAILING = 'FAILING';
     const TOKEN_STATE_COMPLETED = 'COMPLETED';
     const TOKEN_STATE_CLOSED = 'CLOSED';
+    const TOKEN_STATE_SKIPPED = 'SKIPPED';
 
     /**
      * Get Process of the activity.

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/StateInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/StateInterface.php
@@ -35,6 +35,16 @@ interface StateInterface extends TraversableInterface, ObservableInterface, Conn
     public function addNewToken(ExecutionInstanceInterface $instance = null, array $properties = [], TransitionInterface $source = null);
 
     /**
+     * Create token for the current state.
+     *
+     * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface|null $instance
+     * @param array $properties
+     *
+     * @return TokenInterface
+     */
+    public function createToken(ExecutionInstanceInterface $instance = null, array $properties = []);
+
+    /**
      * Add a new token to the current state.
      *
      * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface $instance

--- a/tests/Feature/Engine/MultiInstanceTest.php
+++ b/tests/Feature/Engine/MultiInstanceTest.php
@@ -955,10 +955,9 @@ class MultiInstanceTest extends EngineTestCase
     /**
      * Verify that the data of the instance coincide with the data stored
      *
-     * @param string $instanceId
-     * @param BpmnDocument $bpmnRepository
+     * @param ExecutionInstanceInterface $instance
      *
-     * @return ExecutionInstanceInterface
+     * @return void
      */
     private function verifyStoredInstanceData(ExecutionInstanceInterface $instance)
     {

--- a/tests/Feature/Engine/MultiInstanceTest.php
+++ b/tests/Feature/Engine/MultiInstanceTest.php
@@ -7,6 +7,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\EndEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ProcessInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 use ProcessMaker\Nayra\Storage\BpmnDocument;
 
 /**
@@ -70,6 +71,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the first MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -80,6 +84,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_COMPLETED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the second MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -89,6 +96,9 @@ class MultiInstanceTest extends EngineTestCase
         $this->assertEvents([
             ActivityInterface::EVENT_ACTIVITY_COMPLETED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Complete the third MI activity.
         $token = $miTask->getTokens($instance)->item(0);
@@ -105,6 +115,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
     }
 
     /**
@@ -161,6 +174,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the first MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -170,6 +186,9 @@ class MultiInstanceTest extends EngineTestCase
         $this->assertEvents([
             ActivityInterface::EVENT_ACTIVITY_COMPLETED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Complete the second MI activity.
         $token = $miTask->getTokens($instance)->item(0);
@@ -181,6 +200,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_COMPLETED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the third MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
@@ -191,6 +213,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_EXCEPTION,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Close failing task instance.
         $token->setStatus(ScriptTaskInterface::TOKEN_STATE_CLOSED);
         $this->engine->runToNextState();
@@ -199,6 +224,9 @@ class MultiInstanceTest extends EngineTestCase
         $this->assertEvents([
             ActivityInterface::EVENT_ACTIVITY_CANCELLED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
     }
 
     /**
@@ -255,6 +283,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the first MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -264,6 +295,9 @@ class MultiInstanceTest extends EngineTestCase
         $this->assertEvents([
             ActivityInterface::EVENT_ACTIVITY_COMPLETED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Complete the second MI activity.
         $token = $miTask->getTokens($instance)->item(0);
@@ -275,6 +309,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_COMPLETED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Cancel the third MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $token->setStatus(ScriptTaskInterface::TOKEN_STATE_CLOSED);
@@ -284,6 +321,9 @@ class MultiInstanceTest extends EngineTestCase
         $this->assertEvents([
             ActivityInterface::EVENT_ACTIVITY_CANCELLED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
     }
 
     /**
@@ -336,6 +376,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the first MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -348,6 +391,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the second MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -359,6 +405,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Complete the third MI activity.
         $token = $miTask->getTokens($instance)->item(0);
@@ -373,6 +422,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
     }
 
     /**
@@ -425,6 +477,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the first MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -436,6 +491,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Complete the second MI activity.
         $token = $miTask->getTokens($instance)->item(0);
@@ -449,6 +507,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the third MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
@@ -458,6 +519,9 @@ class MultiInstanceTest extends EngineTestCase
         $this->assertEvents([
             ActivityInterface::EVENT_ACTIVITY_EXCEPTION,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Close failing task instance.
         $token->setStatus(ScriptTaskInterface::TOKEN_STATE_CLOSED);
@@ -520,6 +584,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the first MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -531,6 +598,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Complete the second MI activity.
         $token = $miTask->getTokens($instance)->item(0);
@@ -544,10 +614,16 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Cancel the third MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $token->setStatus(ScriptTaskInterface::TOKEN_STATE_CLOSED);
         $this->engine->runToNextState();
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Assertion: The thrid and last MI task was cancelled, then the process is completed
         $this->assertEvents([
@@ -608,6 +684,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the MI activity.
         $token = $miTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -620,6 +699,9 @@ class MultiInstanceTest extends EngineTestCase
 
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Complete the last task
         $token = $lastTask->getTokens($instance)->item(0);
@@ -697,6 +779,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the MI activity.
         $token1 = $miTask->getTokens($instance)->item(0);
         $token2 = $miTask->getTokens($instance)->item(1);
@@ -714,6 +799,9 @@ class MultiInstanceTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the last task
         $token = $lastTask->getTokens($instance)->item(0);
         $activity->complete($token);
@@ -729,6 +817,9 @@ class MultiInstanceTest extends EngineTestCase
 
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Assertion: Output data 'result' should contain the expected result
         $data = $instance->getDataStore()->getData();
@@ -805,6 +896,9 @@ class MultiInstanceTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
         ]);
 
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
+
         // Complete the MI activity.
         $token1 = $miTask->getTokens($instance)->item(0);
         $token2 = $miTask->getTokens($instance)->item(1);
@@ -821,6 +915,9 @@ class MultiInstanceTest extends EngineTestCase
 
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
+
+        // Assertion: The internal data of the LoopCharacteristics are stored in the instance data.
+        $this->verifyStoredInstanceData($instance);
 
         // Complete the last task
         $token = $lastTask->getTokens($instance)->item(0);
@@ -853,5 +950,24 @@ class MultiInstanceTest extends EngineTestCase
                 'loopCounter' => 2,
             ],
         ], $data['result']);
+    }
+
+    /**
+     * Verify that the data of the instance coincide with the data stored
+     *
+     * @param string $instanceId
+     * @param BpmnDocument $bpmnRepository
+     *
+     * @return ExecutionInstanceInterface
+     */
+    private function verifyStoredInstanceData(ExecutionInstanceInterface $instance)
+    {
+        $instanceId=$instance->getId();
+        $instanceData = $instance->getDataStore()->getData();
+
+        $instanceRepository = $this->repository->createExecutionInstanceRepository();
+        $storageData = $instanceRepository->getInstanceData($instanceId);
+
+        $this->assertEquals($instanceData, $storageData);
     }
 }

--- a/tests/Feature/Patterns/PatternsTest.php
+++ b/tests/Feature/Patterns/PatternsTest.php
@@ -96,6 +96,7 @@ class PatternsTest extends EngineTestCase
      * @param string $startEvent
      * @param array $result
      * @param array $events
+     * @param mixed $output
      *
      * @return void
      */
@@ -182,6 +183,7 @@ class PatternsTest extends EngineTestCase
      * @param mixed $subset
      * @param mixed $data
      * @param string $message
+     * @param bool $skip
      *
      * @return mixed
      */

--- a/tests/Feature/Patterns/PatternsTest.php
+++ b/tests/Feature/Patterns/PatternsTest.php
@@ -83,7 +83,8 @@ class PatternsTest extends EngineTestCase
         $tests = json_decode(file_get_contents($jsonFile), true);
         foreach ($tests as $json) {
             $events = isset($json['events']) ? $json['events'] : [];
-            $this->runProcess($bpmnFile, $json['data'], $json['startEvent'], $json['result'], $events);
+            $output = isset($json['output']) ? $json['output'] : [];
+            $this->runProcess($bpmnFile, $json['data'], $json['startEvent'], $json['result'], $events, $output);
         }
     }
 
@@ -98,7 +99,7 @@ class PatternsTest extends EngineTestCase
      *
      * @return void
      */
-    private function runProcess($filename, $data, $startEvent, $result, $events)
+    private function runProcess($filename, $data, $startEvent, $result, $events, $output)
     {
         $bpmnRepository = new BpmnDocument();
         $bpmnRepository->setEngine($this->engine);
@@ -122,6 +123,9 @@ class PatternsTest extends EngineTestCase
         $tasks = [];
         if (!$instance) {
             $this->assertEquals($result, $tasks);
+            if ($output) {
+                $this->assertEquals($output, $dataStore->getData());
+            }
             return;
         }
         $tokens = $instance->getTokens();
@@ -167,5 +171,49 @@ class PatternsTest extends EngineTestCase
             }
         }
         $this->assertEquals($result, $tasks);
+        if ($output) {
+            $this->assertData($output, $dataStore->getData());
+        }
+    }
+
+    /**
+     * Assert that $data contains the expected $subset
+     *
+     * @param mixed $subset
+     * @param mixed $data
+     * @param string $message
+     *
+     * @return mixed
+     */
+    private function assertData($subset, $data, $message = 'data', $skip = false)
+    {
+        if (!is_array($subset) || !is_array($data)) {
+            if ($skip) {
+                return $subset == $data;
+            } else {
+                return $this->assertEquals($subset, $data, "{$message} does not match " . \json_encode($subset));
+            }
+        }
+        foreach ($subset as $key => $value) {
+            if (substr($key, 0, 1) !== '*') {
+                $this->assertData($value, $data[$key], "{$message}.{$key}");
+                unset($subset[$key]);
+                unset($data[$key]);
+            }
+        }
+        foreach ($subset as $key => $value) {
+            foreach ($data as $key1 => $value1) {
+                if ($this->assertData($value, $value1, "{$message}.{$key}", true)) {
+                    unset($subset[$key]);
+                    unset($data[$key1]);
+                    break;
+                }
+            }
+        }
+        if ($skip) {
+            return count($subset) === 0;
+        } else {
+            $this->assertCount(0, $subset, "{$message} does not match");
+        }
     }
 }

--- a/tests/Feature/Patterns/files/MultiInstance_CardinalityZero.bpmn
+++ b/tests/Feature/Patterns/files/MultiInstance_CardinalityZero.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="task_1" name="Form Task" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_6</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="task_2" name="Form Task" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_8</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+      <bpmn:ioSpecification id="node_9_3">
+        <bpmn:dataOutput id="node_3_output_1" name="output_array_node_3" isCollection="true" />
+        <bpmn:inputSet id="node_12_5" />
+        <bpmn:outputSet id="node_13_6">
+          <bpmn:dataOutputRefs>node_3_output_1</bpmn:dataOutputRefs>
+        </bpmn:outputSet>
+      </bpmn:ioSpecification>
+      <bpmn:multiInstanceLoopCharacteristics id="node_5_1">
+        <bpmn:loopCardinality id="node_3_2">$data['times']</bpmn:loopCardinality>
+        <bpmn:loopDataOutputRef>node_3_output_1</bpmn:loopDataOutputRef>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:task>
+    <bpmn:endEvent id="node_4" name="End Event" pm:screenRef="">
+      <bpmn:incoming>node_15</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_6" sourceRef="node_1" targetRef="task_1" />
+    <bpmn:sequenceFlow id="node_8" sourceRef="task_1" targetRef="task_2" />
+    <bpmn:task id="task_3" name="Form Task" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_13</bpmn:incoming>
+      <bpmn:outgoing>node_15</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_13" sourceRef="task_2" targetRef="task_3" />
+    <bpmn:sequenceFlow id="node_15" sourceRef="task_3" targetRef="node_4" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="240" y="250" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="task_1">
+        <dc:Bounds x="350" y="230" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="task_2">
+        <dc:Bounds x="560" y="230" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="970" y="250" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="258" y="268" />
+        <di:waypoint x="408" y="268" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="408" y="268" />
+        <di:waypoint x="618" y="268" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_11_di" bpmnElement="task_3">
+        <dc:Bounds x="760" y="230" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="618" y="268" />
+        <di:waypoint x="818" y="268" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_15_di" bpmnElement="node_15">
+        <di:waypoint x="818" y="268" />
+        <di:waypoint x="988" y="268" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Feature/Patterns/files/MultiInstance_CardinalityZero.json
+++ b/tests/Feature/Patterns/files/MultiInstance_CardinalityZero.json
@@ -1,0 +1,13 @@
+[
+  {
+    "comment": "If the cardinality value is 0 then the multi-instance activity is skipped and no instances are created.",
+    "startEvent": "node_1",
+    "data": {
+      "times": 0
+    },
+    "result": [
+      "task_1",
+      "task_3"
+    ]
+  }
+]

--- a/tests/Feature/Patterns/files/MultiInstance_EmptyInputItems.bpmn
+++ b/tests/Feature/Patterns/files/MultiInstance_EmptyInputItems.bpmn
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="task_2" name="Task 2" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_7</bpmn:incoming>
+      <bpmn:outgoing>node_15</bpmn:outgoing>
+      <bpmn:ioSpecification id="node_6_2">
+        <bpmn:dataInput id="node_3_input_1" name="items" isCollection="true" />
+        <bpmn:dataOutput id="node_3_output_1" name="output_array_node_3" isCollection="true" />
+        <bpmn:inputSet id="node_12_5">
+          <bpmn:dataInputRefs>node_3_input_1</bpmn:dataInputRefs>
+        </bpmn:inputSet>
+        <bpmn:outputSet id="node_13_6">
+          <bpmn:dataOutputRefs>node_3_output_1</bpmn:dataOutputRefs>
+        </bpmn:outputSet>
+      </bpmn:ioSpecification>
+      <bpmn:multiInstanceLoopCharacteristics id="node_2_1">
+        <bpmn:loopDataInputRef>node_3_input_1</bpmn:loopDataInputRef>
+        <bpmn:loopDataOutputRef>node_3_output_1</bpmn:loopDataOutputRef>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:task>
+    <bpmn:endEvent id="node_4" name="End Event" pm:screenRef="">
+      <bpmn:incoming>node_17</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="task_1" name="Task 1" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_7" sourceRef="task_1" targetRef="task_2" />
+    <bpmn:sequenceFlow id="node_9" sourceRef="node_1" targetRef="task_1" />
+    <bpmn:task id="task_3" name="Task 3" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_15</bpmn:incoming>
+      <bpmn:outgoing>node_17</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_15" sourceRef="task_2" targetRef="task_3" />
+    <bpmn:sequenceFlow id="node_17" sourceRef="task_3" targetRef="node_4" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="270" y="360" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="task_2">
+        <dc:Bounds x="630" y="340" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="1010" y="360" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_12_di" bpmnElement="task_1">
+        <dc:Bounds x="420" y="340" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="478" y="378" />
+        <di:waypoint x="688" y="378" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="288" y="378" />
+        <di:waypoint x="478" y="378" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_13_di" bpmnElement="task_3">
+        <dc:Bounds x="830" y="340" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_15_di" bpmnElement="node_15">
+        <di:waypoint x="688" y="378" />
+        <di:waypoint x="888" y="378" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_17_di" bpmnElement="node_17">
+        <di:waypoint x="888" y="378" />
+        <di:waypoint x="1028" y="378" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Feature/Patterns/files/MultiInstance_EmptyInputItems.json
+++ b/tests/Feature/Patterns/files/MultiInstance_EmptyInputItems.json
@@ -1,0 +1,13 @@
+[
+  {
+    "comment": "If the InputItems is empty then the multi-instance activity is skipped and no instances are created.",
+    "startEvent": "node_1",
+    "data": {
+      "items": []
+    },
+    "result": [
+      "task_1",
+      "task_3"
+    ]
+  }
+]

--- a/tests/Feature/Patterns/files/MultiInstance_InputData.json
+++ b/tests/Feature/Patterns/files/MultiInstance_InputData.json
@@ -4,12 +4,22 @@
     "data": {
       "Users": [{ "name": "David" }, { "name": "Dante" }, { "name": "Marco" }]
     },
-    "result": [
-      "Init",
-      "MITask",
-      "MITask",
-      "MITask",
-      "End"
-    ]
+    "result": ["Init", "MITask", "MITask", "MITask", "End"],
+    "output": {
+      "Users": [{ "name": "David" }, { "name": "Dante" }, { "name": "Marco" }],
+      "loopCharacteristics": {
+        "*token": {
+          "numberOfActiveInstances": 0,
+          "numberOfInstances": 3,
+          "loopCounter": 3,
+          "numberOfCompletedInstances": 3
+        }
+      },
+      "Result": [
+        null,
+        null,
+        null
+      ]
+    }
   }
 ]

--- a/tests/Feature/Patterns/files/MultiInstance_InputData_DefaultItems.bpmn
+++ b/tests/Feature/Patterns/files/MultiInstance_InputData_DefaultItems.bpmn
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1612459215251" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1612459215251" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1612459215251" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <process id="PROCESS_1" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:description/>
+      <yaoqiang:pageFormat height="841.8897637795276" imageableHeight="831.8897637795276" imageableWidth="588.1102362204724" imageableX="5.0" imageableY="5.0" orientation="0" width="598.1102362204724"/>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <ioSpecification>
+      <inputSet/>
+      <outputSet/>
+    </ioSpecification>
+    <scriptTask completionQuantity="1" id="MITask" isForCompensation="false" name="MITask" scriptFormat="text/javascript" startQuantity="1">
+      <incoming>_9</incoming>
+      <outgoing>_10</outgoing>
+      <ioSpecification>
+        <dataInput id="Din_2_1" isCollection="true" name="Users"/>
+        <dataOutput id="Dout_2_1" isCollection="true" name="Result"/>
+        <inputSet>
+          <dataInputRefs>Din_2_1</dataInputRefs>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>Dout_2_1</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <multiInstanceLoopCharacteristics behavior="All">
+        <loopDataInputRef>Din_2_1</loopDataInputRef>
+        <loopDataOutputRef>Dout_2_1</loopDataOutputRef>
+      </multiInstanceLoopCharacteristics>
+    </scriptTask>
+    <startEvent id="_3" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_8</outgoing>
+      <outputSet/>
+    </startEvent>
+    <scriptTask completionQuantity="1" id="Init" isForCompensation="false" name="Init" startQuantity="1">
+      <incoming>_8</incoming>
+      <outgoing>_9</outgoing>
+    </scriptTask>
+    <scriptTask completionQuantity="1" id="End" isForCompensation="false" name="End" startQuantity="1">
+      <incoming>_10</incoming>
+      <outgoing>_7</outgoing>
+    </scriptTask>
+    <sequenceFlow id="_7" sourceRef="End" targetRef="_6"/>
+    <endEvent id="_6" name="End Event">
+      <incoming>_7</incoming>
+      <inputSet/>
+    </endEvent>
+    <sequenceFlow id="_8" sourceRef="_3" targetRef="Init"/>
+    <sequenceFlow id="_9" sourceRef="Init" targetRef="MITask"/>
+    <sequenceFlow id="_10" sourceRef="MITask" targetRef="End"/>
+  </process>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-PROCESS_1" name="Untitled Diagram" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="PROCESS_1">
+      <bpmndi:BPMNShape bpmnElement="MITask" id="Yaoqiang-MITask">
+        <dc:Bounds height="55.0" width="85.0" x="288.6590909090909" y="114.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="45.0" x="308.66" y="134.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" id="Yaoqiang-_3">
+        <dc:Bounds height="32.0" width="32.0" x="63.31818181818184" y="126.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="69.0" x="44.82" y="166.75"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Init" id="Yaoqiang-Init">
+        <dc:Bounds height="55.0" width="85.0" x="162.73863636363635" y="114.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="23.0" x="193.74" y="134.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="End" id="Yaoqiang-End">
+        <dc:Bounds height="55.0" width="85.0" x="414.5795454545454" y="114.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="27.0" x="443.58" y="134.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_6" id="Yaoqiang-_6">
+        <dc:Bounds height="32.0" width="32.0" x="566.9999999999999" y="126.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="552.0" y="166.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_9" id="Yaoqiang-_9">
+        <di:waypoint x="248.0" y="142.0"/>
+        <di:waypoint x="289.0" y="142.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="265.5" y="132.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_10" id="Yaoqiang-_10">
+        <di:waypoint x="374.0" y="142.0"/>
+        <di:waypoint x="415.0" y="142.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="391.5" y="132.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_8" id="Yaoqiang-_8">
+        <di:waypoint x="95.0" y="142.0"/>
+        <di:waypoint x="163.0" y="142.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="126.0" y="132.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_7" id="Yaoqiang-_7">
+        <di:waypoint x="500.0" y="142.0"/>
+        <di:waypoint x="567.0" y="142.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="530.5" y="132.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/Feature/Patterns/files/MultiInstance_InputData_DefaultItems.json
+++ b/tests/Feature/Patterns/files/MultiInstance_InputData_DefaultItems.json
@@ -1,0 +1,25 @@
+[
+  {
+    "startEvent": "_3",
+    "data": {
+      "Users": [{ "name": "David" }, { "name": "Dante" }, { "name": "Marco" }]
+    },
+    "result": ["Init", "MITask", "MITask", "MITask", "End"],
+    "output": {
+      "Users": [{ "name": "David" }, { "name": "Dante" }, { "name": "Marco" }],
+      "loopCharacteristics": {
+        "*token": {
+          "numberOfActiveInstances": 0,
+          "numberOfInstances": 3,
+          "loopCounter": 3,
+          "numberOfCompletedInstances": 3
+        }
+      },
+      "Result": [
+        { "name": "David", "loopCounter": 1 },
+        { "name": "Dante", "loopCounter": 2 },
+        { "name": "Marco", "loopCounter": 3 }
+      ]
+    }
+  }
+]

--- a/tests/Feature/Patterns/files/MultiInstance_InputData_WithInputItem.bpmn
+++ b/tests/Feature/Patterns/files/MultiInstance_InputData_WithInputItem.bpmn
@@ -1,0 +1,115 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1612459215251" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1612459215251" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1612459215251" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <process id="PROCESS_1" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:description/>
+      <yaoqiang:pageFormat height="841.8897637795276" imageableHeight="831.8897637795276" imageableWidth="588.1102362204724" imageableX="5.0" imageableY="5.0" orientation="0" width="598.1102362204724"/>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <ioSpecification>
+      <inputSet/>
+      <outputSet/>
+    </ioSpecification>
+    <scriptTask completionQuantity="1" id="MITask" isForCompensation="false" name="MITask" scriptFormat="text/javascript" startQuantity="1">
+      <incoming>_9</incoming>
+      <outgoing>_10</outgoing>
+      <ioSpecification>
+        <dataInput id="Din_2_1" isCollection="true" name="Users"/>
+        <dataOutput id="Dout_2_1" isCollection="true" name="Result"/>
+        <inputSet>
+          <dataInputRefs>Din_2_1</dataInputRefs>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>Dout_2_1</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <multiInstanceLoopCharacteristics behavior="All">
+        <loopDataInputRef>Din_2_1</loopDataInputRef>
+        <loopDataOutputRef>Dout_2_1</loopDataOutputRef>
+        <inputDataItem id="inputDI_2" isCollection="false" name="User"/>
+      </multiInstanceLoopCharacteristics>
+    </scriptTask>
+    <startEvent id="_3" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_8</outgoing>
+      <outputSet/>
+    </startEvent>
+    <scriptTask completionQuantity="1" id="Init" isForCompensation="false" name="Init" startQuantity="1">
+      <incoming>_8</incoming>
+      <outgoing>_9</outgoing>
+    </scriptTask>
+    <scriptTask completionQuantity="1" id="End" isForCompensation="false" name="End" startQuantity="1">
+      <incoming>_10</incoming>
+      <outgoing>_7</outgoing>
+    </scriptTask>
+    <sequenceFlow id="_7" sourceRef="End" targetRef="_6"/>
+    <endEvent id="_6" name="End Event">
+      <incoming>_7</incoming>
+      <inputSet/>
+    </endEvent>
+    <sequenceFlow id="_8" sourceRef="_3" targetRef="Init"/>
+    <sequenceFlow id="_9" sourceRef="Init" targetRef="MITask"/>
+    <sequenceFlow id="_10" sourceRef="MITask" targetRef="End"/>
+  </process>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-PROCESS_1" name="Untitled Diagram" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="PROCESS_1">
+      <bpmndi:BPMNShape bpmnElement="MITask" id="Yaoqiang-MITask">
+        <dc:Bounds height="55.0" width="85.0" x="288.6590909090909" y="114.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="45.0" x="308.66" y="134.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" id="Yaoqiang-_3">
+        <dc:Bounds height="32.0" width="32.0" x="63.31818181818184" y="126.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="69.0" x="44.82" y="166.75"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Init" id="Yaoqiang-Init">
+        <dc:Bounds height="55.0" width="85.0" x="162.73863636363635" y="114.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="23.0" x="193.74" y="134.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="End" id="Yaoqiang-End">
+        <dc:Bounds height="55.0" width="85.0" x="414.5795454545454" y="114.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="27.0" x="443.58" y="134.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_6" id="Yaoqiang-_6">
+        <dc:Bounds height="32.0" width="32.0" x="566.9999999999999" y="126.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="552.0" y="166.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_9" id="Yaoqiang-_9">
+        <di:waypoint x="248.0" y="142.0"/>
+        <di:waypoint x="289.0" y="142.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="265.5" y="132.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_10" id="Yaoqiang-_10">
+        <di:waypoint x="374.0" y="142.0"/>
+        <di:waypoint x="415.0" y="142.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="391.5" y="132.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_8" id="Yaoqiang-_8">
+        <di:waypoint x="95.0" y="142.0"/>
+        <di:waypoint x="163.0" y="142.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="126.0" y="132.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_7" id="Yaoqiang-_7">
+        <di:waypoint x="500.0" y="142.0"/>
+        <di:waypoint x="567.0" y="142.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="530.5" y="132.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/Feature/Patterns/files/MultiInstance_InputData_WithInputItem.json
+++ b/tests/Feature/Patterns/files/MultiInstance_InputData_WithInputItem.json
@@ -1,0 +1,25 @@
+[
+  {
+    "startEvent": "_3",
+    "data": {
+      "Users": [{ "name": "David" }, { "name": "Dante" }, { "name": "Marco" }]
+    },
+    "result": ["Init", "MITask", "MITask", "MITask", "End"],
+    "output": {
+      "Users": [{ "name": "David" }, { "name": "Dante" }, { "name": "Marco" }],
+      "loopCharacteristics": {
+        "*token": {
+          "numberOfActiveInstances": 0,
+          "numberOfInstances": 3,
+          "loopCounter": 3,
+          "numberOfCompletedInstances": 3
+        }
+      },
+      "Result": [
+        { "User": {"name": "David"}, "loopCounter": 1 },
+        { "User": {"name": "Dante"}, "loopCounter": 2 },
+        { "User": {"name": "Marco"}, "loopCounter": 3 }
+      ]
+    }
+  }
+]

--- a/tests/ProcessMaker/Test/Models/ExecutionInstanceRepository.php
+++ b/tests/ProcessMaker/Test/Models/ExecutionInstanceRepository.php
@@ -69,6 +69,8 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
     /**
      * Get instance data
      *
+     * @param  $instanceId
+     *
      * @return array Data
      */
     public function getInstanceData($instanceId)

--- a/tests/ProcessMaker/Test/Models/ExecutionInstanceRepository.php
+++ b/tests/ProcessMaker/Test/Models/ExecutionInstanceRepository.php
@@ -67,6 +67,16 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
     }
 
     /**
+     * Get instance data
+     *
+     * @return array Data
+     */
+    public function getInstanceData($instanceId)
+    {
+        return static::$data[$instanceId]['data'];
+    }
+
+    /**
      * Creates an execution instance.
      *
      * @return \ProcessMaker\Test\Models\ExecutionInstance
@@ -85,7 +95,8 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
      */
     public function persistInstanceCreated(ExecutionInstanceInterface $instance)
     {
-
+        $id = $instance->getId();
+        self::$data[$id]['data'] = $instance->getDataStore()->getData();
     }
 
     /**
@@ -97,6 +108,8 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
      */
     public function persistInstanceCompleted(ExecutionInstanceInterface $instance)
     {
+        $id = $instance->getId();
+        self::$data[$id]['data'] = $instance->getDataStore()->getData();
     }
 
     /**
@@ -109,5 +122,18 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
      */
     public function persistInstanceCollaboration(ExecutionInstanceInterface $target, ParticipantInterface $targetParticipant, ExecutionInstanceInterface $source, ParticipantInterface $sourceParticipant)
     {
+    }
+
+    /**
+     * Persists instance data related to the event Process Instance Completed
+     *
+     * @param ExecutionInstanceInterface $instance
+     *
+     * @return mixed
+     */
+    public function persistInstanceUpdated(ExecutionInstanceInterface $instance)
+    {
+        $id = $instance->getId();
+        self::$data[$id]['data'] = $instance->getDataStore()->getData();
     }
 }

--- a/tests/ProcessMaker/Test/Models/TokenRepository.php
+++ b/tests/ProcessMaker/Test/Models/TokenRepository.php
@@ -26,6 +26,11 @@ class TokenRepository implements TokenRepositoryInterface
 
     static $failNextPersistanceCall = false;
 
+    /**
+     * Sets to fail on next persistance call
+     *
+     * @return void
+     */
     public static function failNextPersistanceCall()
     {
         static::$failNextPersistanceCall = true;

--- a/tests/ProcessMaker/Test/Models/TokenRepository.php
+++ b/tests/ProcessMaker/Test/Models/TokenRepository.php
@@ -75,6 +75,8 @@ class TokenRepository implements TokenRepositoryInterface
      */
     public function persistActivityActivated(ActivityInterface $activity, TokenInterface $token)
     {
+        $instanceRepository = $token->getInstance()->getProcess()->getRepository()->createExecutionInstanceRepository();
+        $instanceRepository->persistInstanceUpdated($token->getInstance());
         if (static::$failNextPersistanceCall) {
             static::$failNextPersistanceCall = false;
             throw new Exception('Failure expected when activity persists');
@@ -91,6 +93,8 @@ class TokenRepository implements TokenRepositoryInterface
      */
     public function persistActivityException(ActivityInterface $activity, TokenInterface $token)
     {
+        $instanceRepository = $token->getInstance()->getProcess()->getRepository()->createExecutionInstanceRepository();
+        $instanceRepository->persistInstanceUpdated($token->getInstance());
     }
 
     /**
@@ -103,6 +107,8 @@ class TokenRepository implements TokenRepositoryInterface
      */
     public function persistActivityCompleted(ActivityInterface $activity, TokenInterface $token)
     {
+        $instanceRepository = $token->getInstance()->getProcess()->getRepository()->createExecutionInstanceRepository();
+        $instanceRepository->persistInstanceUpdated($token->getInstance());
     }
 
     /**
@@ -115,6 +121,8 @@ class TokenRepository implements TokenRepositoryInterface
      */
     public function persistActivityClosed(ActivityInterface $activity, TokenInterface $token)
     {
+        $instanceRepository = $token->getInstance()->getProcess()->getRepository()->createExecutionInstanceRepository();
+        $instanceRepository->persistInstanceUpdated($token->getInstance());
     }
 
     /**


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-3023

Requires #195 

This PR includes:
- Skip MultiInstance Activity if InputData is empty
- Skip MultiInstance Activity if Cardinality is 0
- Add MultiInstance tests
