### PR TITLE
Fix MultiInstance Sequential CallActivity

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
@@ -112,11 +112,10 @@ trait ActivityTrait
             StateInterface::EVENT_TOKEN_ARRIVED,
             function (TokenInterface $token, TransitionInterface $source) {
                 try {
-                    $sequenceFlow = $source ? $source->getProperty('sequenceFlow') : null;
                     $this->getRepository()
                     ->getTokenRepository()
                     ->persistActivityActivated($this, $token);
-                    $this->notifyEvent(ActivityInterface::EVENT_ACTIVITY_ACTIVATED, $this, $token, $sequenceFlow);
+                    $this->notifyEvent(ActivityInterface::EVENT_ACTIVITY_ACTIVATED, $this, $token);
                 } catch (Exception $exception) {
                     $token->setStatus(ActivityInterface::TOKEN_STATE_FAILING);
                     $token->logError($exception, $this);
@@ -200,7 +199,6 @@ trait ActivityTrait
         $transition->connectTo($this->activeState);
         $emptyDataInput->connectTo($this->skippedState);
         $this->addInput($ready);
-        $transition->setProperty('sequenceFlow', $targetFlow);
         return $ready;
     }
 

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/TransitionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/TransitionInterface.php
@@ -9,7 +9,7 @@ use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
  *
  * @package ProcessMaker\Nayra\Contracts\Bpmn
  */
-interface TransitionInterface extends ConnectionNodeInterface
+interface TransitionInterface extends ConnectionNodeInterface, ObservableInterface
 {
     const EVENT_BEFORE_TRANSIT = 'BeforeTransit';
     const EVENT_AFTER_CONSUME = 'AfterConsume';


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-3323

This PR removes the non more required `sequenceFlow` property from transient used in PM4 CallActiviy.
