### PR TITLE
Add option to do not trigger signal start events

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/ActivityCompletedTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityCompletedTransition.php
@@ -3,44 +3,29 @@
 namespace ProcessMaker\Nayra\Bpmn;
 
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
-use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
 /**
- * Transition rule when a exception is catch.
+ * Transition rule for an activity.
  *
  * @package ProcessMaker\Nayra\Bpmn
  */
-class ExceptionTransition implements TransitionInterface
+class ActivityCompletedTransition implements TransitionInterface
 {
     use TransitionTrait;
-
-    /**
-     * Initialize transition.
-     *
-     */
-    protected function initActivityTransition()
-    {
-        $this->setPreserveToken(true);
-    }
 
     /**
      * Condition required to transit the element.
      *
      * @param TokenInterface|null $token
-     * @param ExecutionInstanceInterface|null $executionInstance
+     * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface|null $executionInstance
      *
      * @return bool
      */
     public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
     {
-        return $token->getStatus() === ActivityInterface::TOKEN_STATE_FAILING;
-    }
-
-    protected function onTokenTransit(TokenInterface $token)
-    {
-        $token->setProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE, ErrorInterface::class);
+        return $token->getStatus() === ActivityInterface::TOKEN_STATE_COMPLETED;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/ActivityExceptionTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityExceptionTransition.php
@@ -2,29 +2,19 @@
 
 namespace ProcessMaker\Nayra\Bpmn;
 
-use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
 /**
- * Transition rule when a exception is catch.
+ * Uncaught Exception Transition.
  *
  * @package ProcessMaker\Nayra\Bpmn
  */
-class ExceptionTransition implements TransitionInterface
+class ActivityExceptionTransition extends BoundaryCaughtTransition implements TransitionInterface
 {
     use TransitionTrait;
-
-    /**
-     * Initialize transition.
-     *
-     */
-    protected function initActivityTransition()
-    {
-        $this->setPreserveToken(true);
-    }
 
     /**
      * Condition required to transit the element.
@@ -36,11 +26,8 @@ class ExceptionTransition implements TransitionInterface
      */
     public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
     {
-        return $token->getStatus() === ActivityInterface::TOKEN_STATE_FAILING;
-    }
-
-    protected function onTokenTransit(TokenInterface $token)
-    {
-        $token->setProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE, ErrorInterface::class);
+        $eventType = $token->getProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE);
+        $matchType = $eventType === ErrorInterface::class || is_a($eventType, ErrorInterface::class);
+        return $matchType;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/ActivityInterruptedTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityInterruptedTransition.php
@@ -22,6 +22,7 @@ class ActivityInterruptedTransition implements TransitionInterface
     protected function initActivityTransition()
     {
         $this->setPreserveToken(true);
+        $this->setTokensConsumedPerIncoming(-1);
     }
 
     /**

--- a/src/ProcessMaker/Nayra/Bpmn/ActivityInterruptedTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityInterruptedTransition.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+/**
+ * Transition rule when an activity is interrupted.
+ *
+ * @package ProcessMaker\Nayra\Bpmn
+ */
+class ActivityInterruptedTransition implements TransitionInterface
+{
+    use TransitionTrait;
+
+    /**
+     * Initialize transition.
+     */
+    protected function initActivityTransition()
+    {
+        $this->setPreserveToken(true);
+    }
+
+    /**
+     * Condition required to transit the element.
+     *
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface|null $token
+     * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface|null $executionInstance
+     *
+     * @return bool
+     */
+    public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
+    {
+        return true;
+    }
+
+    /**
+     * Merge tokens into one token.
+     *
+     * @param CollectionInterface|TokenInterface[] $tokens
+     *
+     * @return TokenInterface|null
+     */
+    protected function mergeTokens(CollectionInterface $consumeTokens)
+    {
+        $properties = [];
+        $chosenToken = null;
+        foreach ($consumeTokens as $token) {
+            if ($token->getOwnerElement() === $this->getOwner()) {
+                $chosenToken = $token;
+            }
+            $properties = array_merge($properties, $token->getProperties());
+        }
+        if ($chosenToken) {
+            $chosenToken->setProperties($properties);
+        }
+        return $chosenToken;
+    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/ActivityInterruptedTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityInterruptedTransition.php
@@ -42,7 +42,7 @@ class ActivityInterruptedTransition implements TransitionInterface
     /**
      * Merge tokens into one token.
      *
-     * @param CollectionInterface|TokenInterface[] $tokens
+     * @param CollectionInterface|TokenInterface[] $consumeTokens
      *
      * @return TokenInterface|null
      */

--- a/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Nayra\Bpmn;
 
 use Exception;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\LoopCharacteristicsInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\StateInterface;
@@ -277,5 +278,25 @@ trait ActivityTrait
     public function setLoopCharacteristics(LoopCharacteristicsInterface $loopCharacteristics)
     {
         return $this->setProperty(ActivityInterface::BPMN_PROPERTY_LOOP_CHARACTERISTICS, $loopCharacteristics);
+    }
+
+    /**
+     * Get the boundary events attached to the activity
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface[]|\ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface
+     */
+    public function getBoundaryEvents()
+    {
+        $boundaryElements = [];
+        $process = $this->getProcess();
+        if ($process) {
+            $events = $process->getEvents();
+            foreach ($events as $event) {
+                if ($event instanceof BoundaryEventInterface && $event->getAttachedTo() === $this) {
+                    $boundaryElements[] = $event;
+                }
+            }
+        }
+        return new Collection($boundaryElements);
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
@@ -133,7 +133,7 @@ trait ActivityTrait
         $this->interruptedState->connectTo($this->closeActiveTransition);
 
         $this->boundaryCaughtTransition->connectTo($this->caughtInterruptionState);
-        $this->caughtInterruptionState->connectTo($this->boundaryCancelActivityTransition)->setAsMainConnection();
+        $this->caughtInterruptionState->connectTo($this->boundaryCancelActivityTransition);
         $this->waitInterruptState->connectTo($this->boundaryCancelActivityTransition);
 
         $this->activeState->connectTo($this->activeInterrupted);

--- a/src/ProcessMaker/Nayra/Bpmn/BoundaryCaughtTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BoundaryCaughtTransition.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+/**
+ * Boundary Caught Transition.
+ *
+ * @package ProcessMaker\Nayra\Bpmn
+ */
+class BoundaryCaughtTransition implements TransitionInterface
+{
+    use TransitionTrait;
+
+    /**
+     * Condition required to transit the element.
+     *
+     * @param TokenInterface|null $token
+     * @param ExecutionInstanceInterface|null $executionInstance
+     *
+     * @return bool
+     */
+    public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
+    {
+        $activity = $this->getOwner();
+        $eventType = $token->getProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE);
+        $eventDefinitionId = $token->getProperty(TokenInterface::BPMN_PROPERTY_EVENT_DEFINITION_CAUGHT);
+        return $this->existsBoundaryFor($activity, $eventType, $eventDefinitionId);
+    }
+
+    /**
+     * Check if activity has a boundary event for the given event definition.
+     *
+     * @param ActivityInterface $activity
+     * @param string $eventDefinitionId
+     *
+     * @return bool
+     */
+    protected function existsBoundaryFor(ActivityInterface $activity, $eventType, $eventDefinitionId)
+    {
+        $catchException = $activity->getBoundaryEvents()->findFirst(function (BoundaryEventInterface $catch) use ($eventDefinitionId) {
+            foreach ($catch->getEventDefinitions() as $eventDefinition) {
+                if ($eventDefinition->getId() === $eventDefinitionId) {
+                    return true;
+                }
+            }
+        });
+        return !empty($catchException);
+    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/BoundaryCaughtTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BoundaryCaughtTransition.php
@@ -37,6 +37,7 @@ class BoundaryCaughtTransition implements TransitionInterface
      * Check if activity has a boundary event for the given event definition.
      *
      * @param ActivityInterface $activity
+     * @param string $eventType
      * @param string $eventDefinitionId
      *
      * @return bool

--- a/src/ProcessMaker/Nayra/Bpmn/BoundaryEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BoundaryEventTrait.php
@@ -202,6 +202,11 @@ trait BoundaryEventTrait
         return $this->getAttachedTo()->getActiveState();
     }
 
+    /**
+     * Notify to complete the boundary event.
+     * 
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface $token
+     */
     public function notifyInternalEvent(TokenInterface $token)
     {
         $instance = $token->getInstance();

--- a/src/ProcessMaker/Nayra/Bpmn/BoundaryEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BoundaryEventTrait.php
@@ -10,6 +10,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\StateInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 use ProcessMaker\Nayra\Contracts\RepositoryInterface;
 
@@ -24,6 +25,17 @@ trait BoundaryEventTrait
     use CatchEventTrait;
 
     /**
+     * @var StateInterface
+     */
+    private $activeState;
+
+
+    /**
+     * @var TransitionInterface
+     */
+    private $outgoingTransition;
+
+    /**
      * Build the transitions that define the element.
      *
      * @param RepositoryInterface $factory
@@ -31,23 +43,31 @@ trait BoundaryEventTrait
     public function buildTransitions(RepositoryInterface $factory)
     {
         $this->setRepository($factory);
-        $this->transition = new Transition($this);
+        $this->transition = new Transition($this, true);
+        $this->outgoingTransition = new Transition($this);
+        $this->interruptActivityTransition = new BoundaryInterruptActivityTransition($this, true);
+        $this->noInterruptActivityTransition = new BoundaryNoInterruptActivityTransition($this, true);
+        $this->activeState = new State($this, BoundaryEventInterface::TOKEN_STATE_ACTIVE);
+        $this->completedState = new State($this, BoundaryEventInterface::TOKEN_STATE_COMPLETED);
+        $this->transition->connectTo($this->activeState);
+        $this->activeState->connectTo($this->interruptActivityTransition);
+        $this->activeState->connectTo($this->noInterruptActivityTransition);
+        $this->noInterruptActivityTransition->connectTo($this->completedState);
+        $this->completedState->connectTo($this->outgoingTransition);
 
         $this->buildEventDefinitionsTransitions(
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED
         );
-
-        $this->transition->attachEvent(Transition::EVENT_AFTER_TRANSIT, function ($transition, Collection $tokens) {
+        $this->interruptActivityTransition->attachEvent(Transition::EVENT_AFTER_TRANSIT, function ($transition, Collection $tokens) {
+            $activity = $this->getAttachedTo();
             foreach ($tokens as $token) {
-                $this->getProcess()->getEngine()->nextState(function () use ($token) {
-                    // Cancel the attachedTo activity
-                    if ($this->getCancelActivity()) {
-                        foreach ($this->getAttachedTo()->getTokens($token->getInstance()) as $token) {
-                            $token->setStatus(ActivityInterface::TOKEN_STATE_CLOSED);
-                        }
-                    }
-                });
+                $eventType = $token->getProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE);
+                $isError = $eventType === ErrorInterface::class || is_a($eventType, ErrorInterface::class);
+                if (!$isError && $this->getCancelActivity() && $activity instanceof ActivityInterface) {
+                    $activity->notifyInterruptingEvent($token);
+                    break;
+                }
             }
         });
     }
@@ -73,7 +93,7 @@ trait BoundaryEventTrait
      */
     protected function buildConnectionTo(FlowInterface $targetFlow)
     {
-        $this->transition->connectTo($targetFlow->getTarget()->getInputPlace($targetFlow));
+        $this->outgoingTransition->connectTo($targetFlow->getTarget()->getInputPlace($targetFlow));
         return $this;
     }
 
@@ -118,7 +138,12 @@ trait BoundaryEventTrait
         foreach ($this->getEventDefinitions() as $index => $eventDefinition) {
             if ($eventDefinition instanceof ErrorEventDefinitionInterface
                 && $eventDefinition->shouldCatchEventDefinition($errorDef)) {
-                $this->triggerPlace[$index]->addNewToken($token->getInstance());
+                $properties = [
+                    TokenInterface::BPMN_PROPERTY_EVENT_ID => null,
+                    TokenInterface::BPMN_PROPERTY_EVENT_DEFINITION_CAUGHT => $eventDefinition->getId(),
+                    TokenInterface::BPMN_PROPERTY_EVENT_TYPE => ErrorInterface::class,
+                ];
+                $this->triggerPlace[$index]->addNewToken($token->getInstance(), $properties);
             }
         }
     }
@@ -175,5 +200,12 @@ trait BoundaryEventTrait
     public function getActiveState()
     {
         return $this->getAttachedTo()->getActiveState();
+    }
+
+    public function notifyInternalEvent(TokenInterface $token)
+    {
+        $instance = $token->getInstance();
+        $properties = $token->getProperties();
+        $this->completedState->addNewToken($instance, $properties);
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/BoundaryExceptionTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BoundaryExceptionTransition.php
@@ -38,6 +38,7 @@ class BoundaryExceptionTransition implements TransitionInterface
      * Check if activity has a boundary event for the given event definition.
      *
      * @param ActivityInterface $activity
+     * @param string $eventType
      *
      * @return bool
      */

--- a/src/ProcessMaker/Nayra/Bpmn/BoundaryExceptionTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BoundaryExceptionTransition.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Bpmn\Models\ErrorEventDefinition;
+use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+/**
+ * Boundary Caught Transition.
+ *
+ * @package ProcessMaker\Nayra\Bpmn
+ */
+class BoundaryExceptionTransition implements TransitionInterface
+{
+    use TransitionTrait;
+
+    /**
+     * Condition required to transit the element.
+     *
+     * @param TokenInterface|null $token
+     * @param ExecutionInstanceInterface|null $executionInstance
+     *
+     * @return bool
+     */
+    public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
+    {
+        $activity = $this->getOwner();
+        $eventType = $token->getProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE);
+        return $this->existsBoundaryErrorFor($activity, $eventType, null);
+    }
+
+    /**
+     * Check if activity has a boundary event for the given event definition.
+     *
+     * @param ActivityInterface $activity
+     *
+     * @return bool
+     */
+    protected function existsBoundaryErrorFor(ActivityInterface $activity, $eventType)
+    {
+        $catchException = $activity->getBoundaryEvents()->findFirst(function (BoundaryEventInterface $catch) use ($eventType) {
+            foreach ($catch->getEventDefinitions() as $eventDefinition) {
+                if ($eventDefinition instanceof ErrorEventDefinition) {
+                    $matchType = $eventType === ErrorInterface::class || is_a($eventType, ErrorInterface::class);
+                    return $matchType && $catch->getCancelActivity();
+                }
+            }
+        });
+        return !empty($catchException);
+    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/BoundaryInterruptActivityTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BoundaryInterruptActivityTransition.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+/**
+ * Check if Boundary cancels the Activity.
+ *
+ * @package ProcessMaker\Nayra\Bpmn
+ */
+class BoundaryInterruptActivityTransition implements TransitionInterface
+{
+    use TransitionTrait;
+
+    /**
+     * Condition required to transit the element.
+     *
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface|null $token
+     * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface|null $executionInstance
+     *
+     * @return bool
+     */
+    public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
+    {
+        $boundary = $this->getOwner();
+        $interrupt = false;
+        if ($boundary instanceof BoundaryEventInterface) {
+            $interrupt = $boundary->getCancelActivity();
+        }
+        return $interrupt;
+    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/BoundaryNoInterruptActivityTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BoundaryNoInterruptActivityTransition.php
@@ -2,30 +2,35 @@
 
 namespace ProcessMaker\Nayra\Bpmn;
 
-use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
 /**
- * Transition rule for an activity.
+ * Check if Boundary does not cancel the Activity.
  *
  * @package ProcessMaker\Nayra\Bpmn
  */
-class ActivityTransition implements TransitionInterface
+class BoundaryNoInterruptActivityTransition implements TransitionInterface
 {
     use TransitionTrait;
 
     /**
      * Condition required to transit the element.
      *
-     * @param TokenInterface|null $token
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface|null $token
      * @param \ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface|null $executionInstance
      *
      * @return bool
      */
     public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
     {
-        return $token->getStatus() === ActivityInterface::TOKEN_STATE_COMPLETED;
+        $boundary = $this->getOwner();
+        $nonInterrupt = false;
+        if ($boundary instanceof BoundaryEventInterface) {
+            $nonInterrupt = !$boundary->getCancelActivity();
+        }
+        return $nonInterrupt;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/CancelActivityTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/CancelActivityTransition.php
@@ -39,6 +39,11 @@ class CancelActivityTransition implements TransitionInterface
         return $token->getStatus() === ActivityInterface::TOKEN_STATE_CLOSED;
     }
 
+    /**
+     * Mark token as cancel event.
+     * 
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface $token
+     */
     protected function onTokenTransit(TokenInterface $token)
     {
         $token->setProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE, CancelInterface::class);

--- a/src/ProcessMaker/Nayra/Bpmn/CancelActivityTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/CancelActivityTransition.php
@@ -3,17 +3,17 @@
 namespace ProcessMaker\Nayra\Bpmn;
 
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
-use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\CancelInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
 /**
- * Transition rule when a exception is catch.
+ * Transition rule to cancel an activity.
  *
  * @package ProcessMaker\Nayra\Bpmn
  */
-class ExceptionTransition implements TransitionInterface
+class CancelActivityTransition implements TransitionInterface
 {
     use TransitionTrait;
 
@@ -36,11 +36,11 @@ class ExceptionTransition implements TransitionInterface
      */
     public function assertCondition(TokenInterface $token = null, ExecutionInstanceInterface $executionInstance = null)
     {
-        return $token->getStatus() === ActivityInterface::TOKEN_STATE_FAILING;
+        return $token->getStatus() === ActivityInterface::TOKEN_STATE_CLOSED;
     }
 
     protected function onTokenTransit(TokenInterface $token)
     {
-        $token->setProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE, ErrorInterface::class);
+        $token->setProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE, CancelInterface::class);
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/CloseExceptionTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/CloseExceptionTransition.php
@@ -8,7 +8,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
 /**
- * Transition rule for an activity in FAILING state.
+ * Transition rule to close an activity in FAILING state.
  *
  * @package ProcessMaker\Nayra\Bpmn
  */

--- a/src/ProcessMaker/Nayra/Bpmn/Connection.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Connection.php
@@ -78,12 +78,4 @@ class Connection implements ConnectionInterface
     {
         return $this->target;
     }
-
-    /**
-     * Set connection as main.
-     */
-    public function setAsMainConnection()
-    {
-        $this->target->setMainConnection($this);
-    }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/Connection.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Connection.php
@@ -78,4 +78,12 @@ class Connection implements ConnectionInterface
     {
         return $this->target;
     }
+
+    /**
+     * Set connection as main.
+     */
+    public function setAsMainConnection()
+    {
+        $this->target->setMainConnection($this);
+    }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
@@ -17,6 +17,9 @@ trait EventDefinitionTrait
 {
     use BaseTrait;
 
+    /**
+     * Initialize event definition ID if it was not defined in the bpmn model.
+     */
     protected function initEventDefinitionTrait()
     {
         $this->setId(uniqid('event-definition-', true));

--- a/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
@@ -31,7 +31,7 @@ trait EventDefinitionTrait
     }
 
     /**
-     * Occures when the catch event was activated
+     * Occurs when the catch event was activated
      *
      * @param EngineInterface $engine
      * @param CatchEventInterface $element
@@ -66,5 +66,28 @@ trait EventDefinitionTrait
     public function getPayloadData(TokenInterface $token = null, CatchEventInterface $target = null)
     {
         return $token ? $token->getInstance()->getDataStore()->getData() : [];
+    }
+
+    /**
+     * Set do not trigger start events
+     *
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function setDoNotTriggerStartEvents($value)
+    {
+        $this->setProperty('doNotTriggerStartEvents', $value);
+        return $this;
+    }
+
+    /**
+     * Get do not trigger start events value
+     *
+     * @return bool
+     */
+    public function getDoNotTriggerStartEvents()
+    {
+        return $this->getProperty('doNotTriggerStartEvents', false);
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
@@ -17,6 +17,11 @@ trait EventDefinitionTrait
 {
     use BaseTrait;
 
+    protected function initEventDefinitionTrait()
+    {
+        $this->setId(uniqid('event-definition-', true));
+    }
+
     /**
      * Register event with a catch event
      *
@@ -89,5 +94,15 @@ trait EventDefinitionTrait
     public function getDoNotTriggerStartEvents()
     {
         return $this->getProperty('doNotTriggerStartEvents', false);
+    }
+
+    /**
+     * Returns the event of the event definition (message, signal, etc.)
+     *
+     * @return SignalInterface|MessageInterface|ErrorInterface|mixed
+     */
+    public function getPayload()
+    {
+        return null;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/ExceptionTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ExceptionTransition.php
@@ -39,6 +39,11 @@ class ExceptionTransition implements TransitionInterface
         return $token->getStatus() === ActivityInterface::TOKEN_STATE_FAILING;
     }
 
+    /**
+     * Mark token as error event.
+     * 
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface $token
+     */
     protected function onTokenTransit(TokenInterface $token)
     {
         $token->setProperty(TokenInterface::BPMN_PROPERTY_EVENT_TYPE, ErrorInterface::class);

--- a/src/ProcessMaker/Nayra/Bpmn/InvalidDataInputTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/InvalidDataInputTransition.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Nayra\Bpmn;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
@@ -64,6 +65,9 @@ class InvalidDataInputTransition implements TransitionInterface
             $error->setId('INVALID_DATA_INPUT');
             $error->setName($errorMessage);
             $properties['error'] = $error;
+            $properties[TokenInterface::BPMN_PROPERTY_EVENT_ID] = null;
+            $properties[TokenInterface::BPMN_PROPERTY_EVENT_DEFINITION_CAUGHT] = null;
+            $properties[TokenInterface::BPMN_PROPERTY_EVENT_TYPE] = ErrorInterface::class;
             $flow->targetState()->addNewToken($instance, $properties, $source);
         }
     }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MultiInstanceLoopCharacteristics.php
@@ -141,8 +141,9 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
                 }
             } else {
                 $numberOfActiveInstances = $numberOfInstances;
+                $newTokens = [];
                 for ($loopCounter = 1; $loopCounter <= $numberOfInstances; $loopCounter++) {
-                    $this->createInstance(
+                    $newTokens[] = $this->createInstance(
                         $instance,
                         $properties,
                         $loopCounter,
@@ -150,8 +151,13 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
                         $nextState,
                         $source,
                         $numberOfActiveInstances,
-                        $numberOfInstances
+                        $numberOfInstances,
+                        true
                     );
+                }
+                // Throw token events
+                foreach($newTokens as $token) {
+                    $nextState->notifyExternalEvent(StateInterface::EVENT_TOKEN_ARRIVED, $token, $source);
                 }
             }
         }
@@ -166,7 +172,7 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
      * @param TransitionInterface $source
      * @param integer $numberOfActiveInstances
      * @param integer $numberOfInstances
-     * @return void
+     * @return TokenInterface
      */
     private function createInstance(
         ExecutionInstanceInterface $instance,
@@ -176,7 +182,8 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
         StateInterface $nextState,
         TransitionInterface $source,
         $numberOfActiveInstances,
-        $numberOfInstances
+        $numberOfInstances,
+        $skipEvents = false
     ) {
         $item = $this->getInputDataItemValue($instance, $loopCounter);
         $properties['data'] = [];
@@ -190,7 +197,7 @@ class MultiInstanceLoopCharacteristics implements MultiInstanceLoopCharacteristi
         $this->setLoopInstanceProperty($newToken, 'numberOfActiveInstances', $numberOfActiveInstances);
         $this->setLoopInstanceProperty($newToken, 'numberOfInstances', $numberOfInstances);
         $this->setLoopInstanceProperty($newToken, 'loopCounter', $loopCounter);
-        $nextState->addToken($instance, $newToken, false, $source);
+        return $nextState->addToken($instance, $newToken, $skipEvents, $source);
     }
 
     /**

--- a/src/ProcessMaker/Nayra/Bpmn/ObservableTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ObservableTrait.php
@@ -64,4 +64,15 @@ trait ObservableTrait
             call_user_func_array($callback, $arguments);
         }
     }
+
+    /**
+     * Notify an external event to the observers.
+     *
+     * @param $event
+     * @param array ...$arguments
+     */
+    public function notifyExternalEvent($event, ...$arguments)
+    {
+        $this->notifyEvent($event, ...$arguments);
+    }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/StartEventTrait.php
@@ -103,16 +103,16 @@ trait StartEventTrait
     /**
      * Method to be called when a message event arrives
      *
-     * @param EventDefinitionInterface $event
+     * @param EventDefinitionInterface $eventDef
      * @param ExecutionInstanceInterface|null $instance
      * @param TokenInterface|null $token
      *
      * @return $this
      */
-    public function execute(EventDefinitionInterface $event, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
+    public function execute(EventDefinitionInterface $eventDef, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
     {
         foreach ($this->getEventDefinitions() as $index => $eventDefinition) {
-            if ($eventDefinition->assertsRule($event, $this, $instance, $token)) {
+            if ($eventDefinition->assertsRule($eventDef, $this, $instance, $token)) {
                 if ($instance === null) {
                     $process = $this->getOwnerProcess();
                     $data =  $eventDefinition->getPayloadData($token, $this);
@@ -121,7 +121,7 @@ trait StartEventTrait
                     $instance = $process->getEngine()->createExecutionInstance($process, $dataStorage);
                 }
                 $this->triggerPlace[$index]->addNewToken($instance);
-                $eventDefinition->execute($event, $this, $instance, $token);
+                $eventDefinition->execute($eventDef, $this, $instance, $token);
             }
         }
         return $this;

--- a/src/ProcessMaker/Nayra/Bpmn/TransitionTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/TransitionTrait.php
@@ -2,12 +2,10 @@
 
 namespace ProcessMaker\Nayra\Bpmn;
 
-use ProcessMaker\Nayra\Bpmn\Models\Flow;
 use ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowElementInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
-use ProcessMaker\Nayra\Contracts\Bpmn\StateInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
@@ -123,7 +121,11 @@ trait TransitionTrait
             if ($this->preserveToken && $consumedTokensCount == 1) {
                 $consumeTokens->find(function (TokenInterface $token) use ($flow, $executionInstance) {
                     $flow->targetState()->addToken($executionInstance, $token, false, $this);
+                    $this->onTokenTransit($token);
                 });
+            } elseif ($this->preserveToken && ($token = $this->mergeTokens($consumeTokens))) {
+                $flow->targetState()->addToken($executionInstance, $token, false, $this);
+                $this->onTokenTransit($token);
             } else {
                 $this->activateNextState($flow, $executionInstance, $consumeTokens, [], $this);
             }
@@ -132,6 +134,21 @@ trait TransitionTrait
         $this->notifyEvent(TransitionInterface::EVENT_AFTER_TRANSIT, $this, $consumeTokens);
 
         return true;
+    }
+
+    /**
+     * Merge tokens into one token.
+     *
+     * @param CollectionInterface|TokenInterface[] $tokens
+     *
+     * @return TokenInterface|null
+     */
+    protected function mergeTokens(CollectionInterface $consumeTokens)
+    {
+        if ($this->getMainConnection()) {
+            error_log($this->getMainConnection()->origin()->getName());
+        }
+        return null;
     }
 
     /**
@@ -278,6 +295,16 @@ trait TransitionTrait
      */
     protected function activateNextState(ConnectionInterface $flow, ExecutionInstanceInterface $instance, CollectionInterface $consumeTokens, array $properties = [], TransitionInterface $source = null)
     {
-        $flow->targetState()->addNewToken($instance, $properties, $source);
+        $token = $flow->targetState()->addNewToken($instance, $properties, $source);
+        $this->onTokenTransit($token);
+    }
+
+    /**
+     * When a token transit.
+     *
+     * @param TokenInterface $token
+     */
+    protected function onTokenTransit(TokenInterface $token)
+    {
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/TransitionTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/TransitionTrait.php
@@ -137,21 +137,6 @@ trait TransitionTrait
     }
 
     /**
-     * Merge tokens into one token.
-     *
-     * @param CollectionInterface|TokenInterface[] $tokens
-     *
-     * @return TokenInterface|null
-     */
-    protected function mergeTokens(CollectionInterface $consumeTokens)
-    {
-        if ($this->getMainConnection()) {
-            error_log($this->getMainConnection()->origin()->getName());
-        }
-        return null;
-    }
-
-    /**
      * Notify in the bus that a conditioned transition has been activated
      *
      * @param mixed $event

--- a/src/ProcessMaker/Nayra/Bpmn/TraversableTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/TraversableTrait.php
@@ -20,7 +20,6 @@ trait TraversableTrait
      */
     private $incoming;
     private $outgoing;
-    private $mainConnection;
 
     /**
      * Initialize incoming/outgoing flows
@@ -92,27 +91,5 @@ trait TraversableTrait
             }
         });
         return new Collection($paths);
-    }
-
-    /**
-     * Set main connection of the node.
-     *
-     * @param \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface $connection
-     *
-     * @return \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionNodeInterface
-     */
-    public function setMainConnection(ConnectionInterface $connection)
-    {
-        $this->mainConnection = $connection;
-    }
-
-    /**
-     * Get main connection of the node.
-     *
-     * @return \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface $connection
-     */
-    protected function getMainConnection()
-    {
-        return $this->mainConnection;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/TraversableTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/TraversableTrait.php
@@ -20,9 +20,10 @@ trait TraversableTrait
      */
     private $incoming;
     private $outgoing;
+    private $mainConnection;
 
     /**
-     * Initialize incomig/outgoing flows
+     * Initialize incoming/outgoing flows
      *
      */
     protected function initFlowElementBehavior()
@@ -91,5 +92,27 @@ trait TraversableTrait
             }
         });
         return new Collection($paths);
+    }
+
+    /**
+     * Set main connection of the node.
+     *
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface $connection
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionNodeInterface
+     */
+    public function setMainConnection(ConnectionInterface $connection)
+    {
+        $this->mainConnection = $connection;
+    }
+
+    /**
+     * Get main connection of the node.
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface $connection
+     */
+    protected function getMainConnection()
+    {
+        return $this->mainConnection;
     }
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/ActivityInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/ActivityInterface.php
@@ -82,4 +82,11 @@ interface ActivityInterface extends FlowNodeInterface
      * @return LoopCharacteristicsInterface
      */
     public function setLoopCharacteristics(LoopCharacteristicsInterface $loopCharacteristics);
+
+    /**
+     * Get the boundary events attached to the activity
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface[]|\ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface
+     */
+    public function getBoundaryEvents();
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/ActivityInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/ActivityInterface.php
@@ -29,10 +29,15 @@ interface ActivityInterface extends FlowNodeInterface
     /**
      * Token states defined for Activity
      */
+    const TOKEN_STATE_READY = 'READY';
     const TOKEN_STATE_ACTIVE = 'ACTIVE';
     const TOKEN_STATE_FAILING = 'FAILING';
     const TOKEN_STATE_COMPLETED = 'COMPLETED';
     const TOKEN_STATE_CLOSED = 'CLOSED';
+    const TOKEN_STATE_INTERRUPTED = 'INTERRUPTED';
+    const TOKEN_STATE_CAUGHT_INTERRUPTION = 'CAUGHT_INTERRUPTION';
+    const TOKEN_STATE_EVENT_INTERRUPTING_EVENT = 'INTERRUPTING_EVENT';
+    const TOKEN_STATE_WAIT_INTERRUPT = 'WAIT_INTERRUPT';
     const TOKEN_STATE_SKIPPED = 'SKIPPED';
 
     /**
@@ -89,4 +94,11 @@ interface ActivityInterface extends FlowNodeInterface
      * @return \ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface[]|\ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface
      */
     public function getBoundaryEvents();
+
+    /**
+     * Notify an event to the element.
+     *
+     * @param TokenInterface $token
+     */
+    public function notifyInterruptingEvent(TokenInterface $token);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/CancelInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/CancelInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ProcessMaker\Nayra\Contracts\Bpmn;
+
+/**
+ * CancelInterface for the CancelEventDefinition.
+ *
+ * @package ProcessMaker\Nayra\Contracts\Bpmn
+ */
+interface CancelInterface extends EntityInterface
+{
+}

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/ConnectionNodeInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/ConnectionNodeInterface.php
@@ -3,7 +3,6 @@
 namespace ProcessMaker\Nayra\Contracts\Bpmn;
 
 use ProcessMaker\Nayra\Bpmn\Collection;
-use ProcessMaker\Nayra\Contracts\Repositories\StorageInterface;
 
 /**
  * Connection node (States and transitions) that define the behavior of
@@ -30,4 +29,13 @@ interface ConnectionNodeInterface extends EntityInterface
      * @param \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionNodeInterface $target
      */
     public function connectTo(ConnectionNodeInterface $target);
+
+    /**
+     * Set main connection of the node.
+     *
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface $connection
+     *
+     * @return \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionNodeInterface
+     */
+    public function setMainConnection(ConnectionInterface $connection);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/ConnectionNodeInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/ConnectionNodeInterface.php
@@ -29,13 +29,4 @@ interface ConnectionNodeInterface extends EntityInterface
      * @param \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionNodeInterface $target
      */
     public function connectTo(ConnectionNodeInterface $target);
-
-    /**
-     * Set main connection of the node.
-     *
-     * @param \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionInterface $connection
-     *
-     * @return \ProcessMaker\Nayra\Contracts\Bpmn\ConnectionNodeInterface
-     */
-    public function setMainConnection(ConnectionInterface $connection);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/EventDefinitionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/EventDefinitionInterface.php
@@ -61,7 +61,7 @@ interface EventDefinitionInterface extends EntityInterface
     public function registerWithCatchEvent(EngineInterface $engine, CatchEventInterface $element);
 
     /**
-     * Occures when the catch event was activated
+     * Occurs when the catch event was activated
      *
      * @param EngineInterface $engine
      * @param CatchEventInterface $element
@@ -89,4 +89,20 @@ interface EventDefinitionInterface extends EntityInterface
      * @return mixed
      */
     public function getPayloadData(TokenInterface $token = null, CatchEventInterface $target = null);
+
+    /**
+     * Set do not trigger start events
+     *
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function setDoNotTriggerStartEvents($value);
+
+    /**
+     * Get do not trigger start events value
+     *
+     * @return bool
+     */
+    public function getDoNotTriggerStartEvents();
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/EventDefinitionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/EventDefinitionInterface.php
@@ -105,4 +105,11 @@ interface EventDefinitionInterface extends EntityInterface
      * @return bool
      */
     public function getDoNotTriggerStartEvents();
+
+    /**
+     * Returns the event of the event definition (message, signal, etc.)
+     *
+     * @return SignalInterface|MessageInterface|ErrorInterface|mixed
+     */
+    public function getPayload();
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/EventInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/EventInterface.php
@@ -45,6 +45,8 @@ interface EventInterface extends FlowNodeInterface
     /**
      * Get Process of the event.
      *
+     * @param \ProcessMaker\Nayra\Contracts\Bpmn\ProcessInterface $process
+     *
      * @return ProcessInterface
      */
     public function setProcess(ProcessInterface $process);

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/EventInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/EventInterface.php
@@ -33,6 +33,7 @@ interface EventInterface extends FlowNodeInterface
      * Token states defined for Event
      */
     const TOKEN_STATE_ACTIVE = 'ACTIVE';
+    const TOKEN_STATE_COMPLETED = 'COMPLETED';
 
     /**
      * Get Process of the event.

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/ObservableInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/ObservableInterface.php
@@ -37,4 +37,12 @@ interface ObservableInterface
      * @param callable $callback
      */
     public function detachEvent($event, callable $callback);
+
+    /**
+     * Notify an external event to the observers.
+     *
+     * @param $event
+     * @param array ...$arguments
+     */
+    public function notifyExternalEvent($event, ...$arguments);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/TokenInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/TokenInterface.php
@@ -15,6 +15,9 @@ interface TokenInterface extends EntityInterface
     const BPMN_PROPERTY_MESSAGE = 'message';
     const BPMN_PROPERTY_STATUS = 'status';
     const BPMN_PROPERTY_INDEX = 'index';
+    const BPMN_PROPERTY_EVENT_ID = 'event_id';
+    const BPMN_PROPERTY_EVENT_DEFINITION_CAUGHT = 'event_definition_caught';
+    const BPMN_PROPERTY_EVENT_TYPE = 'event_type';
 
     /**
      * Get the owner of the token.

--- a/src/ProcessMaker/Nayra/Engine/ExecutionInstanceTrait.php
+++ b/src/ProcessMaker/Nayra/Engine/ExecutionInstanceTrait.php
@@ -45,6 +45,8 @@ trait ExecutionInstanceTrait
      */
     private $tokens;
 
+    public $uniqid;
+
     /**
      * ExecutionInstance constructor.
      *
@@ -54,6 +56,7 @@ trait ExecutionInstanceTrait
      */
     protected function initExecutionInstance()
     {
+        $this->uniqid = \uniqid('', true);
         $this->tokens = new Collection;
     }
 

--- a/tests/Feature/Engine/ActivityTest.php
+++ b/tests/Feature/Engine/ActivityTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Bpmn\Models\Activity;
+use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;
+use ProcessMaker\Nayra\Storage\BpmnDocument;
+use Tests\Feature\Engine\EngineTestCase;
+
+/**
+ * Tests the activity collection
+ *
+ * @package ProcessMaker\Nayra\Bpmn
+ */
+class ActivityTest extends EngineTestCase
+{
+    /**
+     * Test get boundary events from standalone activity
+     */
+    public function testGetEmptyBoundaryEvents()
+    {
+        $element = new Activity();
+        $this->assertCount(0, $element->getBoundaryEvents());
+    }
+
+    /**
+     * Test get boundary events from call activity with boundary events
+     */
+    public function testGetBoundaryEvents()
+    {
+        $bpmnRepository = new BpmnDocument();
+        $bpmnRepository->setEngine($this->engine);
+        $bpmnRepository->setFactory($this->repository);
+        $bpmnRepository->load(__DIR__ . '/files/Error_BoundaryEvent_CallActivity.bpmn');
+
+        // Get boundary events of call activity _7
+        $element = $bpmnRepository->getCallActivity('_7');
+        $boundaryEvents = $element->getBoundaryEvents();
+
+        // Assertion: There is one boundary event with id=_12
+        $this->assertCount(1, $boundaryEvents);
+        $boundaryEvent = $boundaryEvents->item(0);
+        $this->assertInstanceOf(BoundaryEventInterface::class, $boundaryEvent);
+        $this->assertEquals('_12', $boundaryEvent->getId());
+    }
+}

--- a/tests/Feature/Engine/ActivityTest.php
+++ b/tests/Feature/Engine/ActivityTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ProcessMaker\Nayra\Bpmn;
+namespace Tests\Feature\Engine;
 
 use ProcessMaker\Nayra\Bpmn\Models\Activity;
 use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;

--- a/tests/Feature/Engine/BasicsTest.php
+++ b/tests/Feature/Engine/BasicsTest.php
@@ -189,10 +189,38 @@ class BasicsTest extends EngineTestCase
         $instance->close();
         $this->engine->runToNextState();
 
-        //Assertion: Verify that the proces instance was completed
+        //Assertion: Verify that the process instance was completed
         $this->assertEvents([
             ActivityInterface::EVENT_ACTIVITY_CANCELLED,
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
         ]);
+    }
+
+    /**
+     * Test next state callback method.
+     */
+    public function testEngineNextStateCallback()
+    {
+        // Register a next state callback
+        $this->checked = false;
+        $this->engine->nextState(function() {
+            $this->checked = true;
+        });
+        // Load a process
+        $process = $this->createSimpleProcessInstance();
+        $dataStore = $this->repository->createDataStore();
+
+        // create an instance of the process
+        $instance = $this->engine->createExecutionInstance($process, $dataStore);
+
+        // Get References
+        $start = $process->getEvents()->item(0);
+
+        //start the process an instance of the process
+        $start->start($instance);
+        $this->engine->runToNextState();
+
+        // Assertion: Next state callback was executed
+        $this->assertTrue($this->checked);
     }
 }

--- a/tests/Feature/Engine/BoundaryEventTest.php
+++ b/tests/Feature/Engine/BoundaryEventTest.php
@@ -78,10 +78,10 @@ class BoundaryEventTest extends EngineTestCase
             SignalEventDefinitionInterface::EVENT_THROW_EVENT_DEFINITION,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
             EndEventInterface::EVENT_THROW_TOKEN_CONSUMED,
             EndEventInterface::EVENT_EVENT_TRIGGERED,
-            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
 
         // Assertion: Task 1 does not have tokens
@@ -141,8 +141,8 @@ class BoundaryEventTest extends EngineTestCase
         $this->assertEvents([
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ActivityInterface::EVENT_ACTIVITY_CANCELLED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
 
         // Complete second task
@@ -163,7 +163,7 @@ class BoundaryEventTest extends EngineTestCase
     /**
      * Tests a process with an error boundary event attached to a script task
      */
-    public function testErrorBoundaryEventScriptTask()
+    public function testErrorBoundaryEventScript1Task()
     {
         // Load the process from a BPMN file
         $bpmnRepository = new BpmnDocument();
@@ -204,9 +204,9 @@ class BoundaryEventTest extends EngineTestCase
         $this->assertEvents([
             ScriptTaskInterface::EVENT_ACTIVITY_EXCEPTION,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
+            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
-            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
         ]);
 
         // Complete second task
@@ -261,15 +261,15 @@ class BoundaryEventTest extends EngineTestCase
             EndEventInterface::EVENT_EVENT_TRIGGERED,
             EndEventInterface::EVENT_THROW_TOKEN_ARRIVES,
             ErrorEventDefinition::EVENT_THROW_EVENT_DEFINITION,
-            ActivityInterface::EVENT_ACTIVITY_EXCEPTION,
-            BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
             EndEventInterface::EVENT_THROW_TOKEN_CONSUMED,
             EndEventInterface::EVENT_EVENT_TRIGGERED,
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
+            ActivityInterface::EVENT_ACTIVITY_EXCEPTION,
+            BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
 
+            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
-            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
         ]);
 
         // Complete second task
@@ -340,8 +340,8 @@ class BoundaryEventTest extends EngineTestCase
         $this->assertEvents([
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ActivityInterface::EVENT_ACTIVITY_CANCELLED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ActivityInterface::EVENT_ACTIVITY_CANCELLED,
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
         ]);
@@ -401,8 +401,8 @@ class BoundaryEventTest extends EngineTestCase
             IntermediateThrowEventInterface::EVENT_THROW_TOKEN_PASSED,
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ActivityInterface::EVENT_ACTIVITY_CANCELLED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             CallActivityInterface::EVENT_ACTIVITY_CANCELLED,
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
         ]);
@@ -477,9 +477,9 @@ class BoundaryEventTest extends EngineTestCase
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
 
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             EndEventInterface::EVENT_THROW_TOKEN_CONSUMED,
             EndEventInterface::EVENT_EVENT_TRIGGERED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
 
         // Assertion: Task 1 should keep its token
@@ -704,11 +704,11 @@ class BoundaryEventTest extends EngineTestCase
             EndEventInterface::EVENT_EVENT_TRIGGERED,
             EndEventInterface::EVENT_THROW_TOKEN_ARRIVES,
             ErrorEventDefinition::EVENT_THROW_EVENT_DEFINITION,
-            ActivityInterface::EVENT_ACTIVITY_EXCEPTION,
-            BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
             EndEventInterface::EVENT_THROW_TOKEN_CONSUMED,
             EndEventInterface::EVENT_EVENT_TRIGGERED,
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
+            ActivityInterface::EVENT_ACTIVITY_EXCEPTION,
+            BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
 
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
@@ -890,6 +890,9 @@ class BoundaryEventTest extends EngineTestCase
         $timer3Intermediate->execute($timer3Intermediate->getEventDefinitions()->item(0), $subInstance);
         $this->engine->runToNextState();
 
+        // foreach($instance->getTokens() as $token) var_dump($token->getOwnerElement()->getName() . '=' . $token->getStatus());
+        // foreach($subInstance->getTokens() as $token) var_dump($token->getOwnerElement()->getName() . '=' . $token->getStatus());
+
         $this->assertEvents([
             // Assertion: Main process is started
             ProcessInterface::EVENT_PROCESS_INSTANCE_CREATED,
@@ -913,37 +916,40 @@ class BoundaryEventTest extends EngineTestCase
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
 
-            // Assertion: Task 3 and  Task 4 are activated
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+            // Assertion: Call Activity is cancelled
+            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
+
+            // Assertion: Intermediate event is triggered
             IntermediateCatchEventInterface::EVENT_CATCH_TOKEN_CONSUMED,
             IntermediateCatchEventInterface::EVENT_CATCH_MESSAGE_CONSUMED,
             IntermediateCatchEventInterface::EVENT_CATCH_TOKEN_PASSED,
-
-            // Assertion: BoundarySignalEvent catch signal from ThrowSignal
-            BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
             IntermediateThrowEventInterface::EVENT_THROW_TOKEN_ARRIVES,
             IntermediateThrowEventInterface::EVENT_EVENT_TRIGGERED,
-            BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
 
-            // Assertion: Task 2 is activated by BoundarySignalEvent
+            // Assertion: Task 3 and  Task 4 are activated
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+
+            // // Assertion: Interrupting BoundaryTimerEvent move token to the next task
+            // BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CATCH,
+            // BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
+            //
+            // // Assertion: Task 2 is activated by BoundarySignalEvent
+            // ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
 
             // Assertion: ThrowSignal element is completed and goes to next task 5
             IntermediateThrowEventInterface::EVENT_THROW_TOKEN_CONSUMED,
             IntermediateThrowEventInterface::EVENT_THROW_TOKEN_PASSED,
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
-
-            // Assertion: Call Activity is cancelled
-            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
-            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
-            ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
+            //
+            // ActivityInterface::EVENT_ACTIVITY_CANCELLED,
+            // ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
         ]);
 
-        // Assertion: Task 2, Task3, Task 4 are ACTIVE and Task 1 is closed
-        $this->assertEquals(1, $task2->getTokens($instance)->count());
+        // Assertion: Task3, Task 4 are ACTIVE and Task 1 is closed
         $this->assertEquals(1, $task3->getTokens($instance)->count());
         $this->assertEquals(1, $task4->getTokens($instance)->count());
+        $this->assertEquals(1, $task5->getTokens($subInstance)->count());
         $this->assertEquals(0, $task1->getTokens($instance)->count());
     }
 
@@ -1019,9 +1025,7 @@ class BoundaryEventTest extends EngineTestCase
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
 
-            // Assertion: Task 3 and  Task 4 are activated
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
-            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+            // Assertion: IntermediateCatchEvent completed
             IntermediateCatchEventInterface::EVENT_CATCH_TOKEN_CONSUMED,
             IntermediateCatchEventInterface::EVENT_CATCH_MESSAGE_CONSUMED,
             IntermediateCatchEventInterface::EVENT_CATCH_TOKEN_PASSED,
@@ -1032,12 +1036,16 @@ class BoundaryEventTest extends EngineTestCase
             IntermediateThrowEventInterface::EVENT_EVENT_TRIGGERED,
             BoundaryEventInterface::EVENT_BOUNDARY_EVENT_CONSUMED,
 
-            // Assertion: Task 2 is activated by BoundarySignalEvent
+            // Assertion: Task 3 and  Task 4 are activated
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
 
             // Assertion: ThrowSignal element is completed and goes to next task 5
             IntermediateThrowEventInterface::EVENT_THROW_TOKEN_CONSUMED,
             IntermediateThrowEventInterface::EVENT_THROW_TOKEN_PASSED,
+            ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
+
+            // Assertion: Task 2 is activated by BoundarySignalEvent
             ActivityInterface::EVENT_ACTIVITY_ACTIVATED,
         ]);
 

--- a/tests/Feature/Engine/ErrorEndEventTest.php
+++ b/tests/Feature/Engine/ErrorEndEventTest.php
@@ -9,7 +9,6 @@ use ProcessMaker\Nayra\Contracts\Bpmn\EventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ProcessInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
 use ProcessMaker\Nayra\Storage\BpmnDocument;
-use ProcessMaker\Repositories\BpmnFileRepository;
 
 /**
  * Test an error end event.
@@ -119,10 +118,10 @@ class ErrorEndEventTest extends EngineTestCase
             ActivityInterface::EVENT_ACTIVITY_CLOSED,
             EndEventInterface::EVENT_THROW_TOKEN_ARRIVES,
             ErrorEventDefinitionInterface::EVENT_THROW_EVENT_DEFINITION,
-            ActivityInterface::EVENT_ACTIVITY_EXCEPTION,
             EndEventInterface::EVENT_THROW_TOKEN_CONSUMED,
             EndEventInterface::EVENT_EVENT_TRIGGERED,
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
+            ActivityInterface::EVENT_ACTIVITY_EXCEPTION,
         ]);
     }
 }

--- a/tests/Feature/Engine/files/Signal_BoundaryEvent_MultiInstance.bpmn
+++ b/tests/Feature/Engine/files/Signal_BoundaryEvent_MultiInstance.bpmn
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false" pm:assignment="user" pm:assignedUsers="2" pm:assignedGroups="" pm:config="{&#34;web_entry&#34;:null}">
+      <bpmn:outgoing>node_22</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_2" name="Form Task" pm:screenRef="46" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+      <bpmn:incoming>node_16</bpmn:incoming>
+      <bpmn:outgoing>node_24</bpmn:outgoing>
+      <bpmn:ioSpecification id="node_2_inner_1638423509731">
+        <bpmn:dataInput id="node_2_input_1" name="array" isCollection="true" />
+        <bpmn:inputSet id="node_2_inner_1638423509733">
+          <bpmn:dataInputRefs>node_2_input_1</bpmn:dataInputRefs>
+        </bpmn:inputSet>
+        <bpmn:outputSet id="node_2_inner_1638423509734" />
+      </bpmn:ioSpecification>
+      <bpmn:multiInstanceLoopCharacteristics id="node_2_inner_1638423509730">
+        <bpmn:loopDataInputRef>node_2_input_1</bpmn:loopDataInputRef>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:task>
+    <bpmn:endEvent id="node_9" name="End Event">
+      <bpmn:incoming>node_24</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="node_12" name="Boundary Signal Event" attachedToRef="node_2">
+      <bpmn:outgoing>node_15</bpmn:outgoing>
+      <bpmn:signalEventDefinition signalRef="collection_1_update" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="node_13" name="After Boundry" pm:screenRef="46" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+      <bpmn:incoming>node_15</bpmn:incoming>
+      <bpmn:outgoing>node_21</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_15" name="" sourceRef="node_12" targetRef="node_13" />
+    <bpmn:endEvent id="node_19" name="End Event">
+      <bpmn:incoming>node_21</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_21" name="" sourceRef="node_13" targetRef="node_19" />
+    <bpmn:task id="node_3" name="Trigger Signal" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_18</bpmn:incoming>
+      <bpmn:outgoing>node_28</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:parallelGateway id="node_11" name="parallel" gatewayDirection="Diverging">
+      <bpmn:incoming>node_22</bpmn:incoming>
+      <bpmn:outgoing>node_16</bpmn:outgoing>
+      <bpmn:outgoing>node_18</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="node_16" sourceRef="node_11" targetRef="node_2" />
+    <bpmn:sequenceFlow id="node_18" sourceRef="node_11" targetRef="node_3" />
+    <bpmn:sequenceFlow id="node_22" sourceRef="node_1" targetRef="node_11" />
+    <bpmn:sequenceFlow id="node_24" sourceRef="node_2" targetRef="node_9" />
+    <bpmn:endEvent id="node_26" name="Signal End Event">
+      <bpmn:incoming>node_28</bpmn:incoming>
+      <bpmn:signalEventDefinition signalRef="collection_1_update" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_28" sourceRef="node_3" targetRef="node_26" />
+  </bpmn:process>
+  <bpmn:signal id="collection_1_update" name="persons_update" />
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="120" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="390" y="140" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="640" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_12_di" bpmnElement="node_12">
+        <dc:Bounds x="459" y="198" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_13_di" bpmnElement="node_13">
+        <dc:Bounds x="420" y="320" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_15_di" bpmnElement="node_15">
+        <di:waypoint x="477" y="216" />
+        <di:waypoint x="478" y="358" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_19_di" bpmnElement="node_19">
+        <dc:Bounds x="640" y="340" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_21_di" bpmnElement="node_21">
+        <di:waypoint x="478" y="358" />
+        <di:waypoint x="658" y="358" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="390" y="460" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_11_di" bpmnElement="node_11">
+        <dc:Bounds x="240" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_16_di" bpmnElement="node_16">
+        <di:waypoint x="258" y="178" />
+        <di:waypoint x="448" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_18_di" bpmnElement="node_18">
+        <di:waypoint x="258" y="178" />
+        <di:waypoint x="258" y="498" />
+        <di:waypoint x="448" y="498" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_22_di" bpmnElement="node_22">
+        <di:waypoint x="138" y="178" />
+        <di:waypoint x="258" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_24_di" bpmnElement="node_24">
+        <di:waypoint x="448" y="178" />
+        <di:waypoint x="658" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_26_di" bpmnElement="node_26">
+        <dc:Bounds x="640" y="480" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_28_di" bpmnElement="node_28">
+        <di:waypoint x="448" y="498" />
+        <di:waypoint x="658" y="498" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Feature/Engine/files/Signal_Start_Event.bpmn
+++ b/tests/Feature/Engine/files/Signal_Start_Event.bpmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:task id="node_2" name="Task 1" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_5</bpmn:incoming>
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="node_3" name="End Event">
+      <bpmn:incoming>node_7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_7" sourceRef="node_2" targetRef="node_3" />
+    <bpmn:startEvent id="node_8" name="Signal Start Event">
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+      <bpmn:signalEventDefinition signalRef="signal1" />
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_5" sourceRef="node_8" targetRef="node_2" />
+  </bpmn:process>
+  <bpmn:signal id="signal1" name="signal1" />
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="320" y="190" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="510" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="378" y="228" />
+        <di:waypoint x="528" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_8_di" bpmnElement="node_8">
+        <dc:Bounds x="210" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="228" y="228" />
+        <di:waypoint x="378" y="228" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Feature/Patterns/files/CallActivityBoundaryEndSignal.bpmn
+++ b/tests/Feature/Patterns/files/CallActivityBoundaryEndSignal.bpmn
@@ -1,0 +1,155 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1637766729240" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1637766729240" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1637766729240" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <process id="PROCESS_1" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:description/>
+      <yaoqiang:pageFormat height="841.8897637795276" imageableHeight="831.8897637795276" imageableWidth="588.1102362204724" imageableX="5.0" imageableY="5.0" orientation="0" width="598.1102362204724"/>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <startEvent id="_2" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_18</outgoing>
+      <outputSet/>
+    </startEvent>
+    <task completionQuantity="1" id="_7" isForCompensation="false" name="Task" startQuantity="1">
+      <incoming>_21</incoming>
+      <outgoing>_10</outgoing>
+    </task>
+    <sequenceFlow id="_10" sourceRef="_7" targetRef="_9"/>
+    <endEvent id="_9" name="End Event">
+      <incoming>_10</incoming>
+      <inputSet/>
+    </endEvent>
+    <endEvent id="_11" name="End Event">
+      <incoming>_19</incoming>
+      <inputSet/>
+    </endEvent>
+    <callActivity calledElement="PROCESS_2" completionQuantity="1" id="_17" isForCompensation="false" name="Call Activity" startQuantity="1">
+      <incoming>_18</incoming>
+      <outgoing>_19</outgoing>
+      <multiInstanceLoopCharacteristics behavior="All" isSequential="false">
+        <loopCardinality><![CDATA[2]]></loopCardinality>
+      </multiInstanceLoopCharacteristics>
+    </callActivity>
+    <sequenceFlow id="_18" sourceRef="_2" targetRef="_17"/>
+    <sequenceFlow id="_19" sourceRef="_17" targetRef="_11"/>
+    <boundaryEvent attachedToRef="_17" cancelActivity="true" id="_20" name="Boundary Event" parallelMultiple="false">
+      <extensionElements>
+        <yaoqiang:style align="right" labelPosition="left" verticalAlign="middle" verticalLabelPosition="top"/>
+        <yaoqiang:label offset-x="38.68421052631578" offset-y="-16.0" x="0.0" y="0.0"/>
+      </extensionElements>
+      <outgoing>_21</outgoing>
+      <outputSet/>
+      <signalEventDefinition id="_20_ED_1" signalRef="SIG_1"/>
+    </boundaryEvent>
+    <sequenceFlow id="_21" sourceRef="_20" targetRef="_7"/>
+  </process>
+  <globalTask id="GT_1" name="Global Task"/>
+  <process id="PROCESS_2" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <startEvent id="_3" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_4</outgoing>
+      <outputSet/>
+    </startEvent>
+    <sequenceFlow id="_4" sourceRef="_3" targetRef="_14"/>
+    <endEvent id="_14" name="End Event">
+      <incoming>_4</incoming>
+      <inputSet/>
+      <signalEventDefinition id="_14_ED_1" signalRef="SIG_1"/>
+    </endEvent>
+  </process>
+  <signal id="SIG_1" name="SIG_1"/>
+  <globalScriptTask id="GT_2" name="Global Task"/>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-PROCESS_1" name="Parent" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="PROCESS_1">
+      <bpmndi:BPMNShape bpmnElement="_2" id="Yaoqiang-_2">
+        <dc:Bounds height="32.0" width="32.0" x="160.78947368421052" y="205.078947368421"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="69.0" x="142.29" y="246.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_7" id="Yaoqiang-_7">
+        <dc:Bounds height="55.0" width="85.0" x="299.0526315789474" y="56.236842105263136"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="33.0" x="325.05" y="76.33"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_9" id="Yaoqiang-_9">
+        <dc:Bounds height="32.0" width="32.0" x="463.5263157894737" y="67.92105263157893"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="448.53" y="108.84"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_11" id="Yaoqiang-_11">
+        <dc:Bounds height="32.0" width="32.0" x="465.94736842105266" y="208.02631578947364"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="450.95" y="248.94"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_17" id="Yaoqiang-_17" isExpanded="false">
+        <dc:Bounds height="65.0" width="95.0" x="297.10526315789474" y="193.9736842105263"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="70.0" x="309.61" y="219.07"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_20" id="Yaoqiang-_20">
+        <dc:Bounds height="32.0" width="32.0" x="335.7894736842105" y="177.9736842105263"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="95.0" x="240.79" y="154.57"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_19" id="Yaoqiang-_19">
+        <di:waypoint x="392.0" y="226.4736842105263"/>
+        <di:waypoint x="466.0055411257073" y="224.02631578947364"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="426.03" y="215.87"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_18" id="Yaoqiang-_18">
+        <di:waypoint x="192.99575774785234" y="221.078947368421"/>
+        <di:waypoint x="297.0" y="226.4736842105263"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="241.95" y="214.42"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_10" id="Yaoqiang-_10">
+        <di:waypoint x="384.0" y="83.73684210526314"/>
+        <di:waypoint x="464.00701330993184" y="83.92105263157893"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="420.91" y="74.52"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_21" id="Yaoqiang-_21">
+        <di:waypoint x="351.7894736842105" y="178.44875352255715"/>
+        <di:waypoint x="351.7894736842105" y="111.4473684210526"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="348.79" y="135.55"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-PROCESS_2" name="Child" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="PROCESS_2">
+      <bpmndi:BPMNShape bpmnElement="_3" id="Yaoqiang-_3">
+        <dc:Bounds height="32.0" width="32.0" x="169.21052631578948" y="133.49999999999997"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="69.0" x="150.71" y="174.26"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_14" id="Yaoqiang-_14">
+        <dc:Bounds height="32.0" width="32.0" x="404.42105263157896" y="133.02631578947364"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="389.42" y="173.78"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_4" id="Yaoqiang-_4">
+        <di:waypoint x="200.99991343466888" y="149.49999999999997"/>
+        <di:waypoint x="404.0055411257073" y="149.02631578947364"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="299.74" y="140.1"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/Feature/Patterns/files/CallActivityBoundaryEndSignal.json
+++ b/tests/Feature/Patterns/files/CallActivityBoundaryEndSignal.json
@@ -1,0 +1,11 @@
+[
+    {
+        "startEvent": "_2",
+        "data": {},
+        "events": [
+        ],
+        "result": [
+            "_7"
+        ]
+    }
+]

--- a/tests/Feature/Patterns/files/CallActivityBoundarySignal.bpmn
+++ b/tests/Feature/Patterns/files/CallActivityBoundarySignal.bpmn
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1637766729240" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1637766729240" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1637766729240" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <process id="PROCESS_1" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:description/>
+      <yaoqiang:pageFormat height="841.8897637795276" imageableHeight="831.8897637795276" imageableWidth="588.1102362204724" imageableX="5.0" imageableY="5.0" orientation="0" width="598.1102362204724"/>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <startEvent id="_2" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_18</outgoing>
+      <outputSet/>
+    </startEvent>
+    <task completionQuantity="1" id="_7" isForCompensation="false" name="Task" startQuantity="1">
+      <incoming>_21</incoming>
+      <outgoing>_10</outgoing>
+    </task>
+    <sequenceFlow id="_10" sourceRef="_7" targetRef="_9"/>
+    <endEvent id="_9" name="End Event">
+      <incoming>_10</incoming>
+      <inputSet/>
+    </endEvent>
+    <endEvent id="_11" name="End Event">
+      <incoming>_19</incoming>
+      <inputSet/>
+    </endEvent>
+    <callActivity calledElement="PROCESS_2" completionQuantity="1" id="_17" isForCompensation="false" name="Call Activity" startQuantity="1">
+      <incoming>_18</incoming>
+      <outgoing>_19</outgoing>
+      <multiInstanceLoopCharacteristics behavior="All" isSequential="false">
+        <loopCardinality><![CDATA[2]]></loopCardinality>
+      </multiInstanceLoopCharacteristics>
+    </callActivity>
+    <sequenceFlow id="_18" sourceRef="_2" targetRef="_17"/>
+    <sequenceFlow id="_19" sourceRef="_17" targetRef="_11"/>
+    <boundaryEvent attachedToRef="_17" cancelActivity="true" id="_20" name="Boundary Event" parallelMultiple="false">
+      <extensionElements>
+        <yaoqiang:style align="right" labelPosition="left" verticalAlign="middle" verticalLabelPosition="top"/>
+        <yaoqiang:label offset-x="38.68421052631578" offset-y="-16.0" x="0.0" y="0.0"/>
+      </extensionElements>
+      <outgoing>_21</outgoing>
+      <outputSet/>
+      <signalEventDefinition id="_20_ED_1" signalRef="SIG_1"/>
+    </boundaryEvent>
+    <sequenceFlow id="_21" sourceRef="_20" targetRef="_7"/>
+  </process>
+  <globalTask id="GT_1" name="Global Task"/>
+  <process id="PROCESS_2" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <startEvent id="_3" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_15</outgoing>
+      <outputSet/>
+    </startEvent>
+    <intermediateThrowEvent id="_13" name="Intermediate Throw Event">
+      <incoming>_15</incoming>
+      <outgoing>_16</outgoing>
+      <inputSet/>
+      <signalEventDefinition id="_13_ED_1" signalRef="SIG_1"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="_15" sourceRef="_3" targetRef="_13"/>
+    <endEvent id="_14" name="End Event">
+      <incoming>_16</incoming>
+      <inputSet/>
+    </endEvent>
+    <sequenceFlow id="_16" sourceRef="_13" targetRef="_14"/>
+  </process>
+  <signal id="SIG_1" name="SIG_1"/>
+  <globalScriptTask id="GT_2" name="Global Task"/>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-PROCESS_1" name="Parent" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="PROCESS_1">
+      <bpmndi:BPMNShape bpmnElement="_2" id="Yaoqiang-_2">
+        <dc:Bounds height="32.0" width="32.0" x="160.78947368421052" y="205.078947368421"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="69.0" x="142.29" y="245.92"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_7" id="Yaoqiang-_7">
+        <dc:Bounds height="55.0" width="85.0" x="299.0526315789474" y="56.236842105263136"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="33.0" x="325.05" y="76.33"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_9" id="Yaoqiang-_9">
+        <dc:Bounds height="32.0" width="32.0" x="463.5263157894737" y="67.92105263157893"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="448.53" y="108.76"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_11" id="Yaoqiang-_11">
+        <dc:Bounds height="32.0" width="32.0" x="465.94736842105266" y="208.02631578947364"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="450.95" y="248.86"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_17" id="Yaoqiang-_17" isExpanded="false">
+        <dc:Bounds height="65.0" width="95.0" x="297.10526315789474" y="193.9736842105263"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="70.0" x="309.61" y="219.07"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_20" id="Yaoqiang-_20">
+        <dc:Bounds height="32.0" width="32.0" x="335.7894736842105" y="177.9736842105263"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="95.0" x="240.79" y="154.57"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_19" id="Yaoqiang-_19">
+        <di:waypoint x="392.0" y="226.4736842105263"/>
+        <di:waypoint x="466.0055411257073" y="224.02631578947364"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="426.03" y="215.87"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_18" id="Yaoqiang-_18">
+        <di:waypoint x="192.99575774785234" y="221.078947368421"/>
+        <di:waypoint x="297.0" y="226.4736842105263"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="241.95" y="214.42"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_10" id="Yaoqiang-_10">
+        <di:waypoint x="384.0" y="83.73684210526314"/>
+        <di:waypoint x="464.00701330993184" y="83.92105263157893"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="420.91" y="74.52"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_21" id="Yaoqiang-_21">
+        <di:waypoint x="351.7894736842105" y="178.44875352255715"/>
+        <di:waypoint x="351.7894736842105" y="111.4473684210526"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="348.79" y="135.55"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-PROCESS_2" name="Child" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="PROCESS_2">
+      <bpmndi:BPMNShape bpmnElement="_3" id="Yaoqiang-_3">
+        <dc:Bounds height="32.0" width="32.0" x="169.21052631578948" y="133.49999999999997"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="69.0" x="150.71" y="174.18"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_13" id="Yaoqiang-_13">
+        <dc:Bounds height="32.0" width="32.0" x="320.7894736842105" y="142.97368421052627"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="152.0" x="260.79" y="183.65"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_14" id="Yaoqiang-_14">
+        <dc:Bounds height="32.0" width="32.0" x="493.42105263157896" y="144.02631578947364"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="478.42" y="184.7"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_16" id="Yaoqiang-_16">
+        <di:waypoint x="352.99298669006816" y="158.97368421052627"/>
+        <di:waypoint x="493.0055411257073" y="160.02631578947364"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="420.11" y="149.99"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_15" id="Yaoqiang-_15">
+        <di:waypoint x="200.99991343466888" y="149.49999999999997"/>
+        <di:waypoint x="321.00701330993184" y="158.97368421052627"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="258.0" y="144.84"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/Feature/Patterns/files/CallActivityBoundarySignal.json
+++ b/tests/Feature/Patterns/files/CallActivityBoundarySignal.json
@@ -1,0 +1,11 @@
+[
+    {
+        "startEvent": "_2",
+        "data": {},
+        "events": [
+        ],
+        "result": [
+            "_7"
+        ]
+    }
+]

--- a/tests/unit/ProcessMaker/Nayra/Bpmn/ObservableTraitTest.php
+++ b/tests/unit/ProcessMaker/Nayra/Bpmn/ObservableTraitTest.php
@@ -11,9 +11,9 @@ class ObservableTraitTest extends TestCase
     /**
      * Dummy function to test if a callback function is attached/detached
      */
-    public function dummyFunction ()
+    public function dummyFunction()
     {
-       return 'dummy';
+        return 'dummy';
     }
 
     /**
@@ -24,7 +24,7 @@ class ObservableTraitTest extends TestCase
         $dummyGateway = new InclusiveGateway();
 
         //The activity transition will be the object to observe
-        $transition = new ActivityTransition($dummyGateway);
+        $transition = new ActivityCompletedTransition($dummyGateway);
 
         //Assertion: once attached to an event the observer count should be incremented by one
         $transition->attachEvent(TransitionInterface::EVENT_AFTER_CONSUME, [$this,'dummyFunction']);

--- a/tests/unit/ProcessMaker/Nayra/Bpmn/ObservableTraitTest.php
+++ b/tests/unit/ProcessMaker/Nayra/Bpmn/ObservableTraitTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 use ProcessMaker\Nayra\Bpmn\Models\InclusiveGateway;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 
+/**
+ * Test attach/detach observers.
+ */
 class ObservableTraitTest extends TestCase
 {
     /**


### PR DESCRIPTION
## Solution
- Add getter for the BoundaryEvents attached to an Activity Task
```
$activity->getBoundaryEvents();
```
- This PR adds an option to EventDefinitions to do not trigger StartEvents.
```
        // Do not triggers signal start events with this signal (only intermediate and boundary events) See CatchSignalEventProcess
        $eventDefinition->setDoNotTriggerStartEvents(true);
```
- Complete Activity Internal flow to properly implement catch/cancel/complete boundary events, support MultiInstance Tasks and CallActivities.

## How to Test
Some new scenarios tested:
- Boundary Signal Event on a MultiInstance CallActivity, trigger signal with a Collection Event.
- Boundary Signal Event on a MultiInstance CallActivity, trigger signal with an End Event Signal in the main process.
- Boundary Signal Event on a MultiInstance CallActivity, trigger signal with an End Event Signal in the multi-instance sub process.

![image](https://user-images.githubusercontent.com/8028650/145640135-13a92bd9-99bd-44c3-8b39-6ce97da8e6a5.png)
![image](https://user-images.githubusercontent.com/8028650/145640214-defd2e90-85fe-4c63-97ca-d62adc1d24bd.png)

Tested with this sub-processes:
![image](https://user-images.githubusercontent.com/8028650/145640274-e4b84e25-097c-46a0-b8a1-9d8ee0129326.png)
![image](https://user-images.githubusercontent.com/8028650/145644067-53ea0448-aed0-46be-929f-cae3485ed39d.png)

Processes:
[BoundaryMICallActivities.zip](https://github.com/ProcessMaker/nayra/files/7695584/BoundaryMICallActivities.zip)

## Related Tickets & Packages
- [FOUR-4407](https://processmaker.atlassian.net/browse/FOUR-4407)

