### PR TITLE
Fix failing sub process transition

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/ActivitySubProcessTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivitySubProcessTrait.php
@@ -60,8 +60,12 @@ trait ActivitySubProcessTrait
         $this->getCalledElement()->attachEvent(
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
             function ($self, ExecutionInstanceInterface $closedInstance) use ($token, $instance) {
+                $skipStates = [
+                    ActivityInterface::TOKEN_STATE_FAILING,
+                    ActivityInterface::TOKEN_STATE_INTERRUPTED,
+                ];
                 if ($closedInstance->getId() === $instance->getId()
-                && $token->getStatus() !== ActivityInterface::TOKEN_STATE_FAILING) {
+                && !in_array($token->getStatus(), $skipStates)) {
                     $this->completeSubprocess($token, $closedInstance, $instance);
                 }
             }

--- a/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
@@ -227,6 +227,17 @@ trait ActivityTrait
                 $this->notifyEvent(ActivityInterface::EVENT_ACTIVITY_CANCELLED, $this, $transition, $tokens);
             }
         );
+        $this->boundaryExceptionTransition->attachEvent(
+            TransitionInterface::EVENT_AFTER_CONSUME,
+            function ($transition, $tokens) {
+                foreach ($tokens as $token) {
+                    $token->setStatus(ActivityInterface::TOKEN_STATE_CLOSED);
+                    $this->getRepository()
+                        ->getTokenRepository()
+                        ->persistActivityCompleted($this, $token);
+                }
+            }
+        );
         $this->boundaryCancelActivityTransition->attachEvent(
             TransitionInterface::EVENT_AFTER_CONSUME,
             function ($transition, $tokens) {


### PR DESCRIPTION
Fix failing sub process transition
- Close a sub process when a boundary error catches and error.
- Do not complete a sub process when it was interrupted.
