### PR TITLE
FOUR-4917: Wokflow is followed according to the nodes (or sequence of design) and not as expected for users

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/ConditionedExclusiveTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ConditionedExclusiveTransition.php
@@ -72,6 +72,11 @@ class ConditionedExclusiveTransition implements TransitionInterface, Conditioned
         return $this;
     }
 
+    public function getCondition()
+    {
+        return $this->condition;
+    }
+
     /**
      * If the condition is not met.
      *

--- a/src/ProcessMaker/Nayra/Bpmn/ConditionedExclusiveTransition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ConditionedExclusiveTransition.php
@@ -72,11 +72,6 @@ class ConditionedExclusiveTransition implements TransitionInterface, Conditioned
         return $this;
     }
 
-    public function getCondition()
-    {
-        return $this->condition;
-    }
-
     /**
      * If the condition is not met.
      *

--- a/src/ProcessMaker/Nayra/Bpmn/ExclusiveGatewayTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ExclusiveGatewayTrait.php
@@ -106,7 +106,7 @@ trait ExclusiveGatewayTrait
                     ->persistGatewayTokenPassed($this, $token);
             }
 
-            $this->notifyEvent(GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED, $this);
+            $this->notifyEvent(GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED, $this,  $transition, $consumedTokens);
         });
         $this->transition->connectTo($outgoingPlace);
         $outgoingPlace->connectTo($outgoingTransition);

--- a/src/ProcessMaker/Nayra/Bpmn/InclusiveGatewayTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/InclusiveGatewayTrait.php
@@ -106,7 +106,7 @@ trait InclusiveGatewayTrait
                     ->persistGatewayTokenPassed($this, $token);
             }
 
-            $this->notifyEvent(GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED, $this);
+            $this->notifyEvent(GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED, $this,  $transition, $consumedTokens);
         });
         $this->transition->connectTo($outgoingPlace);
         $outgoingPlace->connectTo($outgoingTransition);

--- a/src/ProcessMaker/Nayra/Bpmn/ParallelGatewayTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ParallelGatewayTrait.php
@@ -85,7 +85,7 @@ trait ParallelGatewayTrait
                         ->persistGatewayTokenPassed($this, $token);
                 }
 
-                $this->notifyEvent(GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED, $this, $transition);
+                $this->notifyEvent(GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED, $this,  $transition, $consumedTokens);
             }
         );
         $this->transition->connectTo($outgoingPlace);


### PR DESCRIPTION
As part of fixes for [https://processmaker.atlassian.net/browse/FOUR-4917](https://processmaker.atlassian.net/browse/FOUR-4917)

Adds the token and transition to event notification of the TOKEN_PASSED from gateways. 

Notes for testing:
This PR is associated to another one in PM Core ( https://github.com/ProcessMaker/processmaker/pull/4225). Test them together