### PR TITLE
FOUR-5882: Terminate event not closing all open tasks

### DIFF
--- a/tests/Feature/Engine/TerminateEventTest.php
+++ b/tests/Feature/Engine/TerminateEventTest.php
@@ -78,6 +78,7 @@ class TerminateEventTest extends EngineTestCase
             ScriptTaskInterface::EVENT_SCRIPT_TASK_ACTIVATED,
             ThrowEventInterface::EVENT_THROW_TOKEN_CONSUMED,
             EventInterface::EVENT_EVENT_TRIGGERED,
+            ActivityInterface::EVENT_ACTIVITY_CANCELLED,
             ProcessInterface::EVENT_PROCESS_INSTANCE_COMPLETED,
         ]);
     }


### PR DESCRIPTION
## Issue & Reproduction Steps

- Import the process
[terminate_end_event_original.zip](https://github.com/ProcessMaker/nayra/files/8465617/terminate_end_event_original.zip)
- Run a new request, you should see 3 tasks: Task1, Task2 and Terminate task
- Open "Terminate task" and submit it

Even when the Terminate End Event is triggered, Task 1 and Task 2 are still active. A terminate should close all open tokens of a request.

## Solution
-  Close all tokens of a request

## How to Test
Follow the steps to reproduce and:
- Verify that when submitting "Task 1" it arrives to a normal end event and  just Task 1 is closed. Task 2 and "Terminate Task" should be active
- Verify that when submitting "Terminate Task", all  tasks are closed and the request completed

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-5882](https://processmaker.atlassian.net/browse/FOUR-5882)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.