### PR TITLE
Bugfix/FOUR-6610: Add the condition "if there are no or null conditions then evaluate to false instead of true

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
@@ -18,14 +18,6 @@ trait EventDefinitionTrait
     use BaseTrait;
 
     /**
-     * Initialize event definition ID if it was not defined in the bpmn model.
-     */
-    protected function initEventDefinitionTrait()
-    {
-        $this->setId(uniqid('event-definition-', true));
-    }
-
-    /**
      * Register event with a catch event
      *
      * @param EngineInterface $engine

--- a/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/EventDefinitionTrait.php
@@ -18,6 +18,14 @@ trait EventDefinitionTrait
     use BaseTrait;
 
     /**
+     * Initialize event definition ID if it was not defined in the bpmn model.
+     */
+    protected function initEventDefinitionTrait()
+    {
+        $this->setId(uniqid('event-definition-', true));
+    }
+
+    /**
      * Register event with a catch event
      *
      * @param EngineInterface $engine

--- a/src/ProcessMaker/Nayra/Bpmn/Models/ConditionalEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/ConditionalEventDefinition.php
@@ -43,7 +43,7 @@ class ConditionalEventDefinition implements ConditionalEventDefinitionInterface
             $conditionals = $process->getProperty('conditionals', []);
         }
         // Get previous value
-        $key = $this->getId() ?: $this->getBpmnElement()->getNodePath();
+        $key = $this->getBpmnElement()->getNodePath();
         $previous = $conditionals[$key] ?? null;
         // Evaluate condition
         $condition = $this->getCondition();

--- a/src/ProcessMaker/Nayra/Bpmn/Models/ConditionalEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/ConditionalEventDefinition.php
@@ -47,6 +47,9 @@ class ConditionalEventDefinition implements ConditionalEventDefinitionInterface
         $previous = $conditionals[$key] ?? null;
         // Evaluate condition
         $condition = $this->getCondition();
+        // Conditional in conditional start event should be treated as false when condition is empty and
+        // should not execute. But for Multi Instance Loops and Exclusive gateways it should be treated as
+        // true when conditional is empty, to avoid infinite loops and allows exclusive gateways to run.
         $current = empty($condition->getProperties()['body']) ? false : $condition($data);
         // Update previous value
         $conditionals[$key] = $current;

--- a/src/ProcessMaker/Nayra/Bpmn/Models/ConditionalEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/ConditionalEventDefinition.php
@@ -47,7 +47,7 @@ class ConditionalEventDefinition implements ConditionalEventDefinitionInterface
         $previous = $conditionals[$key] ?? null;
         // Evaluate condition
         $condition = $this->getCondition();
-        $current = $condition($data);
+        $current = empty($condition->getProperties()['body']) ? false : $condition($data);
         // Update previous value
         $conditionals[$key] = $current;
         if ($instance && $target instanceof CatchEventInterface) {

--- a/tests/Feature/Engine/ConditionalStartEventTest.php
+++ b/tests/Feature/Engine/ConditionalStartEventTest.php
@@ -41,4 +41,34 @@ class ConditionalStartEventTest extends EngineTestCase
         // Assertion: One process was started
         $this->assertEquals(1, $process->getInstances()->count());
     }
+
+    /**
+     * Test conditional start event should not trigger when empty condition
+     *
+     */
+    public function testConditionalStartEventShouldNotTriggerWhenEmptyCondition()
+    {
+        // Load a BpmnFile Repository
+        $bpmnRepository = new BpmnDocument();
+        $bpmnRepository->setEngine($this->engine);
+        $bpmnRepository->setFactory($this->repository);
+
+        $bpmnRepository->load(__DIR__ . '/files/Conditional_StartEvent_Empty_Condition.bpmn');
+
+        // Load a process from a bpmn repository by Id
+        $process = $bpmnRepository->getProcess('Conditional_StartEvent');
+        // When the process is loaded into the engine, the conditional start event is evaluated
+        $this->engine->loadProcess($process);
+        $this->engine->runToNextState();
+
+        // Assertion: No process was started
+        $this->assertEquals(0, $process->getInstances()->count());
+
+        // Add the environmental data required by the condition
+        $this->engine->getDataStore()->putData('a', '1');
+        $this->engine->runToNextState();
+
+        // Assertion: One process was started
+        $this->assertEquals(0, $process->getInstances()->count());
+    }
 }

--- a/tests/Feature/Engine/files/Conditional_StartEvent_Empty_Condition.bpmn
+++ b/tests/Feature/Engine/files/Conditional_StartEvent_Empty_Condition.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/20100501/BPMN20.xsd"
+                   id="Conditional_StartEventTest"
+                   targetNamespace="http://dsg.wiai.uniba.de/betsy/bpmn/conditional_StartEvent">
+    <bpmn2:process id="Conditional_StartEvent" isExecutable="true">
+        <bpmn2:startEvent id="StartEvent_1" name="Start">
+            <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+            <bpmn2:conditionalEventDefinition id="_ConditionalEventDefinition_2">
+                <bpmn2:condition xsi:type="bpmn2:tFormalExpression"></bpmn2:condition>
+            </bpmn2:conditionalEventDefinition>
+        </bpmn2:startEvent>
+
+        <bpmn2:sequenceFlow id="SequenceFlow_2" name="" sourceRef="StartEvent_1" targetRef="start"/>
+
+        <bpmn2:scriptTask id="start" name="Start">
+            <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+            <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+            <bpmn2:script>CREATE_LOG_FILE</bpmn2:script>
+        </bpmn2:scriptTask>
+
+        <bpmn2:sequenceFlow id="SequenceFlow_3" name="" sourceRef="start" targetRef="end"/>
+
+        <bpmn2:scriptTask id="end" name="End">
+            <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+            <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
+            <bpmn2:script>SCRIPT_task1</bpmn2:script>
+        </bpmn2:scriptTask>
+
+        <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="end" targetRef="EndEvent_2"/>
+
+        <bpmn2:endEvent id="EndEvent_2">
+            <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+        </bpmn2:endEvent>
+    </bpmn2:process>
+</bpmn2:definitions>


### PR DESCRIPTION
## Issue and steps to reproduce
Please see [FOUR-6610](https://processmaker.atlassian.net/browse/FOUR-6610) and [PM4EH-133](https://processmaker.atlassian.net/browse/PM4EH-133)

Conditional start events with empty condition, should not trigger

**Steps to reproduce**

- Create a process with a conditional start event
- Left condition empty or with false value in the conditional start event
- php artisan bpmn:timer

Current behavior:
Process with empty condition are triggered

Expected behavior:
Process with empty condition should not be triggered


## Solution

**Working video**
- Removed $this->getId() and use only node path to get the conditionals key, because an issue related to the generation of randomly new ids for the same node.
- Return false in case condition is empty, so it will be not processed

https://user-images.githubusercontent.com/90727999/186179715-ce63f30d-a2f7-403d-adff-7d319b91f61a.mov


https://user-images.githubusercontent.com/90727999/186179780-5b6c88fc-5575-4d9f-9ccf-a68369e68862.mov



## How to test

Follow steps to reproduce

## Related tickets

- [FOUR-6610](https://processmaker.atlassian.net/browse/FOUR-6610) 
- [PM4EH-133](https://processmaker.atlassian.net/browse/PM4EH-133)

