### PR TITLE
Fix token to be closed on boundary event

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
@@ -108,7 +108,7 @@ trait ActivityTrait
 
         $this->activityInterruptedTransition = new ActivityInterruptedTransition($this, true);
         $this->activityInterruptedTransition->attachEvent(
-            TransitionInterface::EVENT_AFTER_TRANSIT,
+            TransitionInterface::EVENT_BEFORE_TRANSIT,
             function ($transition, $consumedTokens) {
                 foreach ($consumedTokens as $token) {
                     $previousState = $token->getOwner()->getName();


### PR DESCRIPTION
Fix token to be closed on boundary event

## Related tickets
- https://processmaker.atlassian.net/browse/FOUR-10219