### PR TITLE
FOUR-11368 Fix input data for StandardLoop

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/Models/StandardLoopCharacteristics.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/StandardLoopCharacteristics.php
@@ -52,8 +52,7 @@ class StandardLoopCharacteristics implements StandardLoopCharacteristicsInterfac
     private function getInputDataItemValue(ExecutionInstanceInterface $instance, $index)
     {
         $dataStore = $instance->getDataStore();
-
-        return $dataStore;
+        return $dataStore->getData();
     }
 
     /**


### PR DESCRIPTION
Fix input data for StandardLoop, it should return and associative array not a DataStore object.
