### PR TITLE
FOUR-15486 Fix flow elements evaluates only once running tests cases

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/ActivityTrait.php
@@ -235,8 +235,14 @@ trait ActivityTrait
                 foreach ($tokens as $token) {
                     foreach ($boundaryEvents as $boundaryEvent) {
                         $caughtEventDefinition = $token->getProperty(TokenInterface::BPMN_PROPERTY_EVENT_DEFINITION_CAUGHT);
+                        $caughtEventId = $token->getProperty(TokenInterface::BPMN_PROPERTY_EVENT_ID);
                         foreach ($boundaryEvent->getEventDefinitions() as $eventDefinition) {
-                            if ($caughtEventDefinition === $eventDefinition->getId()) {
+                            $payload = $eventDefinition->getPayload();
+                            $eventDefinitionId = $payload ? $payload->getId() : null;
+                            $hasPayloadId = !empty($caughtEventId) && !empty($eventDefinitionId);
+                            $matchPayload = $hasPayloadId && ($caughtEventId === $eventDefinitionId);
+                            $matchEventDefinition = !$hasPayloadId && ($caughtEventDefinition === $eventDefinition->getId());
+                            if ($matchEventDefinition || $matchPayload) {
                                 $boundaryEvent->notifyInternalEvent($token);
                                 break 3;
                             }


### PR DESCRIPTION
## Fix flow elements evaluates only once running tests cases

## Solution
- Fix multiple message problem

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15486

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

