### PR TITLE
FOUR-26839 Improve Message Catch and Throw Events Elements to configure the Message Payload

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Run PHPUnit tests
         run: ./vendor/bin/phpunit -d memory_limit=-1
 
-      - name: List coverage files
-        run: ls -l coverage
+      - name: Check coverage
+        run: ./check_coverage.php
 
       - uses: sonarsource/sonarqube-scan-action@master
         env:

--- a/src/ProcessMaker/Nayra/Bpmn/Assignment.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Assignment.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\AssignmentInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\FormalExpressionInterface;
+
+/**
+ * Assignment class that implements AssignmentInterface
+ */
+class Assignment implements AssignmentInterface
+{
+    use BaseTrait;
+
+    /**
+     * Get the 'from' formal expression.
+     *
+     * @return FormalExpressionInterface
+     */
+    public function getFrom()
+    {
+        return $this->getProperty(self::BPMN_PROPERTY_FROM);
+    }
+
+    /**
+     * Get the 'to' formal expression.
+     *
+     * @return FormalExpressionInterface
+     */
+    public function getTo()
+    {
+        return $this->getProperty(self::BPMN_PROPERTY_TO);
+    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/Assignment.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Assignment.php
@@ -15,7 +15,7 @@ class Assignment implements AssignmentInterface
     /**
      * Get the 'from' formal expression.
      *
-     * @return FormalExpressionInterface
+     * @return FormalExpressionInterface|callable
      */
     public function getFrom()
     {
@@ -25,7 +25,7 @@ class Assignment implements AssignmentInterface
     /**
      * Get the 'to' formal expression.
      *
-     * @return FormalExpressionInterface
+     * @return FormalExpressionInterface|callable
      */
     public function getTo()
     {

--- a/src/ProcessMaker/Nayra/Bpmn/BaseTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BaseTrait.php
@@ -204,10 +204,6 @@ trait BaseTrait
     {
         $this->properties[$name] = isset($this->properties[$name]) ? $this->properties[$name] : new Collection;
         $this->properties[$name]->push($value);
-        $localNameSetter = 'set' . $name . 's';
-        if (isset($this->$localNameSetter)) {
-            $this->$localNameSetter($this->properties[$name]);
-        }
 
         return $this;
     }

--- a/src/ProcessMaker/Nayra/Bpmn/BaseTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/BaseTrait.php
@@ -204,6 +204,10 @@ trait BaseTrait
     {
         $this->properties[$name] = isset($this->properties[$name]) ? $this->properties[$name] : new Collection;
         $this->properties[$name]->push($value);
+        $localNameSetter = 'set' . $name . 's';
+        if (isset($this->$localNameSetter)) {
+            $this->$localNameSetter($this->properties[$name]);
+        }
 
         return $this;
     }

--- a/src/ProcessMaker/Nayra/Bpmn/DataInputAssociation.php
+++ b/src/ProcessMaker/Nayra/Bpmn/DataInputAssociation.php
@@ -11,7 +11,12 @@ class DataInputAssociation implements DataInputAssociationInterface
 {
     use BaseTrait;
 
-    public function getSources()
+    protected function initDataInputAssociation()
+    {
+        $this->properties[static::BPMN_PROPERTY_ASSIGNMENT] = new Collection;
+    }
+
+    public function getSource()
     {
         return $this->getProperty(static::BPMN_PROPERTY_SOURCES_REF);
     }

--- a/src/ProcessMaker/Nayra/Bpmn/DataInputAssociation.php
+++ b/src/ProcessMaker/Nayra/Bpmn/DataInputAssociation.php
@@ -11,14 +11,20 @@ class DataInputAssociation implements DataInputAssociationInterface
 {
     use BaseTrait;
 
-    public function getSources() {}
+    public function getSources()
+    {
+        return $this->getProperty(static::BPMN_PROPERTY_SOURCES_REF);
+    }
 
     public function getTarget()
     {
         return $this->getProperty(static::BPMN_PROPERTY_TARGET_REF);
     }
 
-    public function getTransformation() {}
+    public function getTransformation()
+    {
+        return $this->getProperty(static::BPMN_PROPERTY_TRANSFORMATION);
+    }
 
     public function getAssignments()
     {

--- a/src/ProcessMaker/Nayra/Bpmn/DataInputAssociation.php
+++ b/src/ProcessMaker/Nayra/Bpmn/DataInputAssociation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\DataInputAssociationInterface;
+
+/**
+ * Transition to check if the activity is a loop not yet completed or a single instance
+ */
+class DataInputAssociation implements DataInputAssociationInterface
+{
+    use BaseTrait;
+
+    public function getSources() {}
+
+    public function getTarget()
+    {
+        return $this->getProperty(static::BPMN_PROPERTY_TARGET_REF);
+    }
+
+    public function getTransformation() {}
+
+    public function getAssignments()
+    {
+        return $this->getProperty(static::BPMN_PROPERTY_ASSIGNMENT);
+    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/DataStoreTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/DataStoreTrait.php
@@ -102,6 +102,36 @@ trait DataStoreTrait
     }
 
     /**
+     * Get data using dot notation.
+     *
+     * @param string $path Dot notation path (e.g., 'user.profile.name')
+     * @param mixed $default Default value if path doesn't exist
+     *
+     * @return mixed
+     */
+    public function getDotData($path, $default = null)
+    {
+        $keys = explode('.', $path);
+        $current = $this->data;
+        
+        // Navigate through the path
+        foreach ($keys as $key) {
+            // Handle numeric keys for arrays
+            if (is_numeric($key)) {
+                $key = (int) $key;
+            }
+            
+            if (!isset($current[$key])) {
+                return $default;
+            }
+            
+            $current = $current[$key];
+        }
+        
+        return $current;
+    }
+
+    /**
      * Set data using dot notation.
      *
      * @param string $path Dot notation path (e.g., 'user.profile.name')

--- a/src/ProcessMaker/Nayra/Bpmn/DataStoreTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/DataStoreTrait.php
@@ -100,4 +100,43 @@ trait DataStoreTrait
     {
         return $this->itemSubject;
     }
+
+    /**
+     * Set data using dot notation.
+     *
+     * @param string $path Dot notation path (e.g., 'user.profile.name')
+     * @param mixed $value Value to set
+     *
+     * @return $this
+     */
+    public function setDotData($path, $value)
+    {
+        $keys = explode('.', $path);
+        $current = &$this->data;
+        
+        // Navigate to the parent of the target key
+        for ($i = 0; $i < count($keys) - 1; $i++) {
+            $key = $keys[$i];
+            
+            // Handle numeric keys for arrays
+            if (is_numeric($key)) {
+                $key = (int) $key;
+            }
+            
+            if (!isset($current[$key]) || !is_array($current[$key])) {
+                $current[$key] = [];
+            }
+            $current = &$current[$key];
+        }
+        
+        // Set the final value
+        $finalKey = $keys[count($keys) - 1];
+        if (is_numeric($finalKey)) {
+            $finalKey = (int) $finalKey;
+        }
+        
+        $current[$finalKey] = $value;
+        
+        return $this;
+    }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/EndEvent.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/EndEvent.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Nayra\Bpmn\Models;
 
+use ProcessMaker\Nayra\Bpmn\Collection;
 use ProcessMaker\Nayra\Bpmn\EndEventTrait;
 use ProcessMaker\Nayra\Contracts\Bpmn\EndEventInterface;
 use ProcessMaker\Nayra\Model\DataInputAssociationInterface;
@@ -19,11 +20,17 @@ class EndEvent implements EndEventInterface
 {
     use EndEventTrait;
 
-    private $dataInputs;
-
-    private $dataInputAssociations;
-
     private $inputSet;
+
+    /**
+     * Initialize intermediate throw event.
+     */
+    protected function initEndEvent()
+    {
+        $this->properties[static::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION] = new Collection();
+        $this->properties[static::BPMN_PROPERTY_DATA_INPUT] = new Collection;
+        $this->setProperty(static::BPMN_PROPERTY_EVENT_DEFINITIONS, new Collection);
+    }
 
     /**
      * Array map of custom event classes for the bpmn element.
@@ -52,7 +59,7 @@ class EndEvent implements EndEventInterface
      */
     public function getDataInputs()
     {
-        return $this->dataInputs;
+        return $this->getProperty(static::BPMN_PROPERTY_DATA_INPUT);
     }
 
     /**
@@ -62,7 +69,7 @@ class EndEvent implements EndEventInterface
      */
     public function getDataInputAssociations()
     {
-        return $this->getDataInputAssociations();
+        return $this->getProperty(static::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION);
     }
 
     /**

--- a/src/ProcessMaker/Nayra/Bpmn/Models/IntermediateThrowEvent.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/IntermediateThrowEvent.php
@@ -14,16 +14,6 @@ class IntermediateThrowEvent implements IntermediateThrowEventInterface
     use IntermediateThrowEventTrait;
 
     /**
-     * @var \ProcessMaker\Nayra\Contracts\Bpmn\DataInputAssociationInterface[]
-     */
-    private $dataInputAssociations;
-
-    /**
-     * @var \ProcessMaker\Nayra\Contracts\Bpmn\DataInputInterface[]
-     */
-    private $dataInputs;
-
-    /**
      * @var \ProcessMaker\Nayra\Contracts\Bpmn\InputSetInterface
      */
     private $inputSet;
@@ -38,8 +28,8 @@ class IntermediateThrowEvent implements IntermediateThrowEventInterface
      */
     protected function initIntermediateThrowEvent()
     {
-        $this->dataInputAssociations = new Collection;
-        $this->dataInputs = new Collection;
+        $this->properties[static::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION] = new Collection;
+        $this->properties[static::BPMN_PROPERTY_DATA_INPUT] = new Collection;
         $this->setProperty(static::BPMN_PROPERTY_EVENT_DEFINITIONS, new Collection);
     }
 
@@ -60,7 +50,7 @@ class IntermediateThrowEvent implements IntermediateThrowEventInterface
      */
     public function getDataInputAssociations()
     {
-        return $this->dataInputAssociations;
+        return $this->getProperty(static::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION);
     }
 
     /**
@@ -70,7 +60,7 @@ class IntermediateThrowEvent implements IntermediateThrowEventInterface
      */
     public function getDataInputs()
     {
-        return $this->dataInputs;
+        return $this->getProperty(static::BPMN_PROPERTY_DATA_INPUT);
     }
 
     /**

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
@@ -94,6 +94,14 @@ class MessageEventDefinition implements MessageEventDefinitionInterface
         return $this;
     }
 
+    /**
+     * Evaluate the message payload
+     *
+     * @param ThrowEventInterface $throwEvent
+     * @param TokenInterface $token
+     * @param ExecutionInstanceInterface $targetInstance
+     * @return void
+     */
     private function evaluateMessagePayload(ThrowEventInterface $throwEvent, TokenInterface $token, ExecutionInstanceInterface $targetInstance)
     {
         // Initialize message payload
@@ -107,35 +115,63 @@ class MessageEventDefinition implements MessageEventDefinitionInterface
             $data = $sourceDataStore->getData();
             $source = $association->getSource();
             $target = $association->getTarget();
-            $transformation = $association->getTransformation();
 
             // Add reference to source
             $hasSource = $source && $source->getName();
             $hasTarget = $target && $target->getName();
             $data['sourceRef'] = $hasSource ? $sourceDataStore->getDotData($source->getName()) : null;
 
-            // Apply transformation if exists
-            if ($hasTarget && $transformation && is_callable($transformation)) {
-                $value = $transformation($data);
-                $payload[] = ['key' => $target->getName(), 'value' => $value];
-            } elseif ($hasTarget && $hasSource) {
-                $payload[] = ['key' => $target->getName(), 'value' => $data['sourceRef']];
-            }
+            // Apply transformation
+            $this->applyTransformation($association, $data, $payload, $hasTarget, $hasSource);
 
             // Evaluate assignments
-            $assignments = $association->getAssignments();
-            foreach ($assignments as $assignment) {
-                $from = $assignment->getFrom();
-                $to = trim($assignment->getTo()->getBody());
-                if (is_callable($from)) {
-                    $payload[] = ['key' => $to, 'value' => $from($data)];
-                }
-            }
+            $this->evaluateAssignments($association, $data, $payload);
         }
         // Update data into target $instance
         $dataStore = $targetInstance->getDataStore();
         foreach ($payload as $load) {
             $dataStore->setDotData($load['key'], $load['value']);
+        }
+    }
+
+    /**
+     * Apply transformation to the data and add to payload
+     *
+     * @param mixed $association
+     * @param array $data
+     * @param array &$payload
+     * @param bool $hasTarget
+     * @param bool $hasSource
+     */
+    private function applyTransformation($association, array $data, array &$payload, bool $hasTarget, bool $hasSource)
+    {
+        $transformation = $association->getTransformation();
+        $target = $association->getTarget();
+
+        if ($hasTarget && $transformation && is_callable($transformation)) {
+            $value = $transformation($data);
+            $payload[] = ['key' => $target->getName(), 'value' => $value];
+        } elseif ($hasTarget && $hasSource) {
+            $payload[] = ['key' => $target->getName(), 'value' => $data['sourceRef']];
+        }
+    }
+
+    /**
+     * Evaluate assignments and add to payload
+     *
+     * @param mixed $association
+     * @param array $data
+     * @param array &$payload
+     */
+    private function evaluateAssignments($association, array $data, array &$payload)
+    {
+        $assignments = $association->getAssignments();
+        foreach ($assignments as $assignment) {
+            $from = $assignment->getFrom();
+            $to = trim($assignment->getTo()?->getBody());
+            if (is_callable($from)) {
+                $payload[] = ['key' => $to, 'value' => $from($data)];
+            }
         }
     }
 

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
@@ -96,7 +96,6 @@ class MessageEventDefinition implements MessageEventDefinitionInterface
 
     private function evaluateMessagePayload(ThrowEventInterface $throwEvent, TokenInterface $token, ExecutionInstanceInterface $targetInstance)
     {
-        $dataInputs = $throwEvent->getDataInputs();
         // Initialize message payload
         $payload = [];
         // Associate data inputs to message payload

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
@@ -169,7 +169,7 @@ class MessageEventDefinition implements MessageEventDefinitionInterface
         foreach ($assignments as $assignment) {
             $from = $assignment->getFrom();
             $to = trim($assignment->getTo()?->getBody());
-            if (is_callable($from)) {
+            if (is_callable($from) && !empty($to)) {
                 $payload[] = ['key' => $to, 'value' => $from($data)];
             }
         }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
@@ -107,8 +107,8 @@ class MessageEventDefinition implements MessageEventDefinitionInterface
         // Initialize message payload
         $payload = [];
         $associations = $throwEvent->getDataInputAssociations();
-        // Get data from source token instance
-        $sourceDataStore = $token->getInstance()->getDataStore();
+        // Get data from source token instance or empty one if not found
+        $sourceDataStore = $token->getInstance()?->getDataStore() ?? new DataStore();
 
         // Associate data inputs to message payload
         foreach ($associations as $association) {

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/AssignmentInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/AssignmentInterface.php
@@ -7,6 +7,9 @@ namespace ProcessMaker\Nayra\Contracts\Bpmn;
  */
 interface AssignmentInterface extends EntityInterface
 {
+    const BPMN_PROPERTY_FROM = 'from';
+    const BPMN_PROPERTY_TO = 'to';
+
     /**
      * @return FormalExpressionInterface
      */

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/DataAssociationInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/DataAssociationInterface.php
@@ -10,9 +10,9 @@ interface DataAssociationInterface extends EntityInterface
     /**
      * Get the source of the data association.
      *
-     * @return ItemAwareElementInterface[]
+     * @return ItemAwareElementInterface
      */
-    public function getSources();
+    public function getSource();
 
     /**
      * Get the target of the data association.

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/DataAssociationInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/DataAssociationInterface.php
@@ -31,5 +31,5 @@ interface DataAssociationInterface extends EntityInterface
     /**
      * @return AssignmentInterface[]
      */
-    public function getAssignmentInterfaces();
+    public function getAssignments();
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/DataInputAssociationInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/DataInputAssociationInterface.php
@@ -7,4 +7,6 @@ namespace ProcessMaker\Nayra\Contracts\Bpmn;
  */
 interface DataInputAssociationInterface extends DataAssociationInterface
 {
+    const BPMN_PROPERTY_TARGET_REF = 'targetRef';
+    const BPMN_PROPERTY_ASSIGNMENT = 'assignment';
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/DataInputAssociationInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/DataInputAssociationInterface.php
@@ -7,6 +7,8 @@ namespace ProcessMaker\Nayra\Contracts\Bpmn;
  */
 interface DataInputAssociationInterface extends DataAssociationInterface
 {
-    const BPMN_PROPERTY_TARGET_REF = 'targetRef';
     const BPMN_PROPERTY_ASSIGNMENT = 'assignment';
+    const BPMN_PROPERTY_SOURCES_REF = 'sourceRef';
+    const BPMN_PROPERTY_TARGET_REF = 'targetRef';
+    const BPMN_PROPERTY_TRANSFORMATION = 'transformation';
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/DataStoreInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/DataStoreInterface.php
@@ -86,4 +86,14 @@ interface DataStoreInterface extends ItemAwareElementInterface
      * @return $this
      */
     public function setDotData($path, $value);
+
+    /**
+     * Get data using dot notation.
+     *
+     * @param string $path Dot notation path (e.g., 'user.profile.name')
+     * @param mixed $default Default value if path doesn't exist
+     *
+     * @return mixed
+     */
+    public function getDotData($path, $default = null);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/DataStoreInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/DataStoreInterface.php
@@ -76,4 +76,14 @@ interface DataStoreInterface extends ItemAwareElementInterface
      * @return $this
      */
     public function putData($name, $data);
+
+    /**
+     * Set data using dot notation.
+     *
+     * @param string $path Dot notation path (e.g., 'user.profile.name')
+     * @param mixed $value Value to set
+     *
+     * @return $this
+     */
+    public function setDotData($path, $value);
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/EventInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/EventInterface.php
@@ -10,6 +10,9 @@ use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
 interface EventInterface extends FlowNodeInterface
 {
     const BPMN_PROPERTY_EVENT_DEFINITIONS = 'eventDefinitions';
+    const BPMN_PROPERTY_DATA_INPUT = 'dataInput';
+    const BPMN_PROPERTY_DATA_INPUT_SET = 'inputSet';
+    const BPMN_PROPERTY_DATA_INPUT_ASSOCIATION = 'dataInputAssociation';
 
     const TYPE_START = 'START';
 

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/FormalExpressionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/FormalExpressionInterface.php
@@ -39,4 +39,13 @@ interface FormalExpressionInterface extends EntityInterface
      * @param string $body
      */
     public function setBody($body);
+
+    /**
+     * Invoke the format expression.
+     *
+     * @param mixed $data
+     *
+     * @return string
+     */
+    public function __invoke($data);
 }

--- a/src/ProcessMaker/Nayra/RepositoryTrait.php
+++ b/src/ProcessMaker/Nayra/RepositoryTrait.php
@@ -3,6 +3,8 @@
 namespace ProcessMaker\Nayra;
 
 use InvalidArgumentException;
+use ProcessMaker\Nayra\Bpmn\Assignment;
+use ProcessMaker\Nayra\Bpmn\DataInputAssociation;
 use ProcessMaker\Nayra\Bpmn\Lane;
 use ProcessMaker\Nayra\Bpmn\LaneSet;
 use ProcessMaker\Nayra\Bpmn\Models\Activity;
@@ -480,5 +482,15 @@ trait RepositoryTrait
     public function createStandardLoopCharacteristics()
     {
         return new StandardLoopCharacteristics();
+    }
+
+    public function createDataInputAssociation()
+    {
+        return new DataInputAssociation();
+    }
+
+    public function createAssignment()
+    {
+        return new Assignment();
     }
 }

--- a/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
+++ b/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
@@ -382,10 +382,19 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
                 DataInputAssociationInterface::class,
                 [
                     DataInputAssociationInterface::BPMN_PROPERTY_TARGET_REF => ['1', [self::BPMN_MODEL, DataInputAssociationInterface::BPMN_PROPERTY_TARGET_REF]],
+                    DataInputAssociationInterface::BPMN_PROPERTY_SOURCES_REF => ['1', [self::BPMN_MODEL, DataInputAssociationInterface::BPMN_PROPERTY_SOURCES_REF]],
                     DataInputAssociationInterface::BPMN_PROPERTY_ASSIGNMENT => ['n', [self::BPMN_MODEL, DataInputAssociationInterface::BPMN_PROPERTY_ASSIGNMENT]],
+                    DataInputAssociationInterface::BPMN_PROPERTY_TRANSFORMATION => ['1', [self::BPMN_MODEL, DataInputAssociationInterface::BPMN_PROPERTY_TRANSFORMATION]],
                 ],
             ],
             DataInputAssociationInterface::BPMN_PROPERTY_TARGET_REF => [self::IS_REFERENCE, []],
+            DataInputAssociationInterface::BPMN_PROPERTY_SOURCES_REF => [self::IS_REFERENCE, []],
+            DataInputAssociationInterface::BPMN_PROPERTY_TRANSFORMATION => [
+                FormalExpressionInterface::class,
+                [
+                    FormalExpressionInterface::BPMN_PROPERTY_BODY => ['1', self::DOM_ELEMENT_BODY],
+                ],
+            ],
             DataInputAssociationInterface::BPMN_PROPERTY_ASSIGNMENT => [
                 AssignmentInterface::class,
                 [

--- a/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
+++ b/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
@@ -6,11 +6,13 @@ use DOMDocument;
 use DOMElement;
 use DOMXPath;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\AssignmentInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\CallActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\CatchEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\CollaborationInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ConditionalEventDefinitionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\DataInputAssociationInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\DataInputInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\DataOutputInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\DataStoreInterface;
@@ -371,6 +373,36 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
                     FlowNodeInterface::BPMN_PROPERTY_INCOMING => ['n', [self::BPMN_MODEL, FlowNodeInterface::BPMN_PROPERTY_INCOMING]],
                     FlowNodeInterface::BPMN_PROPERTY_OUTGOING => ['n', [self::BPMN_MODEL, FlowNodeInterface::BPMN_PROPERTY_OUTGOING]],
                     IntermediateThrowEventInterface::BPMN_PROPERTY_EVENT_DEFINITIONS => ['n', EventDefinitionInterface::class],
+                    IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT => ['n', [self::BPMN_MODEL, IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT]],
+                    IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_SET => ['1', [self::BPMN_MODEL, IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_SET]],
+                    IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION => ['n', [self::BPMN_MODEL, IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION]],
+                ],
+            ],
+            'dataInputAssociation' => [
+                DataInputAssociationInterface::class,
+                [
+                    DataInputAssociationInterface::BPMN_PROPERTY_TARGET_REF => ['1', [self::BPMN_MODEL, DataInputAssociationInterface::BPMN_PROPERTY_TARGET_REF]],
+                    DataInputAssociationInterface::BPMN_PROPERTY_ASSIGNMENT => ['n', [self::BPMN_MODEL, DataInputAssociationInterface::BPMN_PROPERTY_ASSIGNMENT]],
+                ],
+            ],
+            DataInputAssociationInterface::BPMN_PROPERTY_TARGET_REF => [self::IS_REFERENCE, []],
+            DataInputAssociationInterface::BPMN_PROPERTY_ASSIGNMENT => [
+                AssignmentInterface::class,
+                [
+                    AssignmentInterface::BPMN_PROPERTY_FROM => ['1', [self::BPMN_MODEL, AssignmentInterface::BPMN_PROPERTY_FROM]],
+                    AssignmentInterface::BPMN_PROPERTY_TO => ['1', [self::BPMN_MODEL, AssignmentInterface::BPMN_PROPERTY_TO]],
+                ],
+            ],
+            AssignmentInterface::BPMN_PROPERTY_FROM => [
+                FormalExpressionInterface::class,
+                [
+                    FormalExpressionInterface::BPMN_PROPERTY_BODY => ['1', self::DOM_ELEMENT_BODY],
+                ],
+            ],
+            AssignmentInterface::BPMN_PROPERTY_TO => [
+                FormalExpressionInterface::class,
+                [
+                    FormalExpressionInterface::BPMN_PROPERTY_BODY => ['1', self::DOM_ELEMENT_BODY],
                 ],
             ],
             'signalEventDefinition' => [

--- a/tests/Feature/Patterns/files/MessageEventToParent.bpmn
+++ b/tests/Feature/Patterns/files/MessageEventToParent.bpmn
@@ -10,6 +10,7 @@
         <participant id="Participant_1f4jbtu" name="main" processRef="Process_1" />
         <participant id="Participant_0qod0gz" name="sub-process" processRef="Process_1gn8a5z" />
     </collaboration>
+    <dataStore id="ds_email" name="user.email"/>
     <process id="Process_1" isExecutable="false">
         <startEvent id="StartEvent">
             <outgoing>SequenceFlow_0h21x7r</outgoing>
@@ -47,7 +48,7 @@
         <scriptTask id="Task_B" name="B" scriptFormat="application/x-betsy">
             <incoming>Flow_1a3yzli</incoming>
             <outgoing>Flow_0ntd3ys</outgoing>
-            <script><![CDATA[return ['user' => ['firstname' => 'admin', 'lastname' => 'user']];]]></script>
+            <script><![CDATA[return ['user' => ['firstname' => 'admin', 'lastname' => 'user', 'username' => 'admin', 'email' => 'admin@example.com']];]]></script>
         </scriptTask>
         <scriptTask id="Task_E" name="E" scriptFormat="application/x-betsy">
             <incoming>Flow_1r1agfn</incoming>
@@ -65,17 +66,25 @@
             <incoming>Flow_0ntd3ys</incoming>
             <outgoing>Flow_1r1agfn</outgoing>
             <!-- Define the input of the message -->
-            <dataInput id="din_fullName" name="fullName" /> <!-- N -->
+            <dataInput id="din_login" name="login" /> <!-- N -->
             <dataInput id="din_status" name="status" /> <!-- N -->
-            <!-- Data association -->
+            <dataInput id="din_email" name="email" /> <!-- N -->
+            <!-- Simple Data association -->
             <dataInputAssociation> <!-- N -->
-                <targetRef>din_fullName</targetRef>
+                <targetRef>din_email</targetRef>
+                <sourceRef>ds_email</sourceRef>
+            </dataInputAssociation>
+            <!-- Data association with transformation and assignment -->
+            <dataInputAssociation> <!-- N -->
+                <targetRef>din_login</targetRef>
+                <transformation><![CDATA[ strtoupper("{$data['user']['username']}") ]]></transformation>
                 <assignment> <!-- N -->
                     <!-- FEEL expression mapping -->
                     <from><![CDATA[ "{$data['user']['firstname']} {$data['user']['lastname']}" ]]></from>
                     <to>fullName</to>
                 </assignment>
             </dataInputAssociation>
+            <!-- Data association with dot notation assignment -->
             <dataInputAssociation> <!-- N -->
                 <targetRef>din_status</targetRef>
                 <assignment> <!-- N -->
@@ -91,7 +100,8 @@
             </dataInputAssociation>
             <!-- InputSet definition -->
             <inputSet> <!-- N -->
-                <dataInputRefs>din_fullName</dataInputRefs>
+                <dataInputRefs>din_email</dataInputRefs>
+                <dataInputRefs>din_login</dataInputRefs>
                 <dataInputRefs>din_status</dataInputRefs>
             </inputSet>
             <!-- Message Event Definition -->

--- a/tests/Feature/Patterns/files/MessageEventToParent.bpmn
+++ b/tests/Feature/Patterns/files/MessageEventToParent.bpmn
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn"
+    exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="18.6.1">
+    <collaboration id="Collaboration_0utf0sd">
+        <participant id="Participant_1f4jbtu" name="main" processRef="Process_1" />
+        <participant id="Participant_0qod0gz" name="sub-process" processRef="Process_1gn8a5z" />
+    </collaboration>
+    <process id="Process_1" isExecutable="false">
+        <startEvent id="StartEvent">
+            <outgoing>SequenceFlow_0h21x7r</outgoing>
+        </startEvent>
+        <endEvent id="Event_0tpzg6j">
+            <incoming>Flow_148wtcr</incoming>
+        </endEvent>
+        <callActivity id="Task_A" name="A" calledElement="Process_1gn8a5z">
+            <incoming>SequenceFlow_0h21x7r</incoming>
+            <outgoing>Flow_1r89qx6</outgoing>
+        </callActivity>
+        <scriptTask id="Task_F" name="F">
+            <incoming>Flow_1r89qx6</incoming>
+            <outgoing>Flow_148wtcr</outgoing>
+        </scriptTask>
+        <scriptTask id="Task_D" name="D">
+            <incoming>Flow_0azzp4i</incoming>
+        </scriptTask>
+        <sequenceFlow id="Flow_148wtcr" sourceRef="Task_F" targetRef="Event_0tpzg6j" />
+        <sequenceFlow id="SequenceFlow_0h21x7r" sourceRef="StartEvent" targetRef="Task_A" />
+        <sequenceFlow id="Flow_1r89qx6" sourceRef="Task_A" targetRef="Task_F" />
+        <sequenceFlow id="Flow_0azzp4i" sourceRef="Event_1t89oqd" targetRef="Task_D" />
+        <boundaryEvent id="Event_1t89oqd" cancelActivity="false" attachedToRef="Task_A">
+            <outgoing>Flow_0azzp4i</outgoing>
+            <messageEventDefinition id="MessageEventDefinition_0z3vg33" />
+        </boundaryEvent>
+    </process>
+    <process id="Process_1gn8a5z">
+        <startEvent id="Event_1jwnr1y">
+            <outgoing>Flow_1a3yzli</outgoing>
+        </startEvent>
+        <endEvent id="Event_19thta4">
+            <incoming>Flow_09pcqxs</incoming>
+        </endEvent>
+        <scriptTask id="Task_B" name="B" scriptFormat="application/x-betsy">
+            <incoming>Flow_1a3yzli</incoming>
+            <outgoing>Flow_0ntd3ys</outgoing>
+            <script><![CDATA[return ['user' => ['firstname' => 'admin', 'lastname' => 'user']];]]></script>
+        </scriptTask>
+        <scriptTask id="Task_E" name="E" scriptFormat="application/x-betsy">
+            <incoming>Flow_1r1agfn</incoming>
+            <outgoing>Flow_09pcqxs</outgoing>
+            <script><![CDATA[
+                // clear sub process data
+                $data = []; return [];
+            ]]></script>
+        </scriptTask>
+        <sequenceFlow id="Flow_1a3yzli" sourceRef="Event_1jwnr1y" targetRef="Task_B" />
+        <sequenceFlow id="Flow_09pcqxs" sourceRef="Task_E" targetRef="Event_19thta4" />
+        <sequenceFlow id="Flow_0ntd3ys" sourceRef="Task_B" targetRef="Event_C" />
+        <sequenceFlow id="Flow_1r1agfn" sourceRef="Event_C" targetRef="Task_E" />
+        <intermediateThrowEvent id="Event_C" name="C">
+            <incoming>Flow_0ntd3ys</incoming>
+            <outgoing>Flow_1r1agfn</outgoing>
+            <!-- Define the input of the message -->
+            <dataInput id="din_fullName" name="fullName" /> <!-- N -->
+            <dataInput id="din_status" name="status" /> <!-- N -->
+            <!-- Data association -->
+            <dataInputAssociation> <!-- N -->
+                <targetRef>din_fullName</targetRef>
+                <assignment> <!-- N -->
+                    <!-- FEEL expression mapping -->
+                    <from><![CDATA[ "{$data['user']['firstname']} {$data['user']['lastname']}" ]]></from>
+                    <to>fullName</to>
+                </assignment>
+            </dataInputAssociation>
+            <dataInputAssociation> <!-- N -->
+                <targetRef>din_status</targetRef>
+                <assignment> <!-- N -->
+                    <!-- FEEL expression mapping -->
+                    <from><![CDATA[ "COMPLETED" ]]></from>
+                    <to>status.name</to>
+                </assignment>
+                <assignment> <!-- N -->
+                    <!-- FEEL expression mapping -->
+                    <from><![CDATA[ "The task has been completed" ]]></from>
+                    <to>status.description</to>
+                </assignment>
+            </dataInputAssociation>
+            <!-- InputSet definition -->
+            <inputSet> <!-- N -->
+                <dataInputRefs>din_fullName</dataInputRefs>
+                <dataInputRefs>din_status</dataInputRefs>
+            </inputSet>
+            <!-- Message Event Definition -->
+            <messageEventDefinition id="MessageEventDefinition_1ihpiso" />
+        </intermediateThrowEvent>
+    </process>
+    <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+        <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Collaboration_0utf0sd">
+            <bpmndi:BPMNShape id="Participant_1f4jbtu_di" bpmnElement="Participant_1f4jbtu"
+                isHorizontal="true">
+                <omgdc:Bounds x="160" y="60" width="630" height="250" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0tpzg6j_di" bpmnElement="Event_0tpzg6j">
+                <omgdc:Bounds x="722" y="232" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="StartEvent_di" bpmnElement="StartEvent">
+                <omgdc:Bounds x="212" y="232" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <omgdc:Bounds x="124" y="275" width="73" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1nv96va_di" bpmnElement="Task_A">
+                <omgdc:Bounds x="338" y="210" width="100" height="80" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1jrjxm3_di" bpmnElement="Task_F">
+                <omgdc:Bounds x="533" y="210" width="100" height="80" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1bz9cme_di" bpmnElement="Task_D">
+                <omgdc:Bounds x="460" y="90" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0mt9bns_di" bpmnElement="Event_1t89oqd">
+                <omgdc:Bounds x="370" y="192" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_148wtcr_di" bpmnElement="Flow_148wtcr">
+                <omgdi:waypoint x="633" y="250" />
+                <omgdi:waypoint x="722" y="250" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="SequenceFlow_0h21x7r_di" bpmnElement="SequenceFlow_0h21x7r">
+                <omgdi:waypoint x="248" y="250" />
+                <omgdi:waypoint x="338" y="250" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1r89qx6_di" bpmnElement="Flow_1r89qx6">
+                <omgdi:waypoint x="438" y="250" />
+                <omgdi:waypoint x="533" y="250" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0azzp4i_di" bpmnElement="Flow_0azzp4i">
+                <omgdi:waypoint x="388" y="192" />
+                <omgdi:waypoint x="388" y="130" />
+                <omgdi:waypoint x="460" y="130" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Participant_0qod0gz_di" bpmnElement="Participant_0qod0gz"
+                isHorizontal="true">
+                <omgdc:Bounds x="160" y="340" width="630" height="250" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_1jwnr1y_di" bpmnElement="Event_1jwnr1y">
+                <omgdc:Bounds x="212" y="442" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_19thta4_di" bpmnElement="Event_19thta4">
+                <omgdc:Bounds x="722" y="442" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0ttojsf_di" bpmnElement="Task_B">
+                <omgdc:Bounds x="305" y="420" width="100" height="80" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0rxm6q1_di" bpmnElement="Task_E">
+                <omgdc:Bounds x="565" y="420" width="100" height="80" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_12cu2ng_di" bpmnElement="Event_C">
+                <omgdc:Bounds x="467" y="442" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <omgdc:Bounds x="481" y="485" width="8" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_1a3yzli_di" bpmnElement="Flow_1a3yzli">
+                <omgdi:waypoint x="248" y="460" />
+                <omgdi:waypoint x="305" y="460" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_09pcqxs_di" bpmnElement="Flow_09pcqxs">
+                <omgdi:waypoint x="665" y="460" />
+                <omgdi:waypoint x="722" y="460" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0ntd3ys_di" bpmnElement="Flow_0ntd3ys">
+                <omgdi:waypoint x="405" y="460" />
+                <omgdi:waypoint x="467" y="460" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1r1agfn_di" bpmnElement="Flow_1r1agfn">
+                <omgdi:waypoint x="503" y="460" />
+                <omgdi:waypoint x="565" y="460" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/Feature/Patterns/files/MessageEventToParent.json
+++ b/tests/Feature/Patterns/files/MessageEventToParent.json
@@ -1,0 +1,21 @@
+[
+    {
+        "comment": "Message event sent multiple data inputs to parent",
+        "startEvent": "StartEvent",
+        "data": {
+        },
+        "result": [
+            "Task_B",
+            "Task_D",
+            "Task_E",
+            "Task_F"
+        ],
+        "output": {
+            "fullName": "admin user",
+            "status": {
+                "name": "COMPLETED",
+                "description": "The task has been completed"
+            }
+        }
+    }
+]

--- a/tests/Feature/Patterns/files/MessageEventToParent.json
+++ b/tests/Feature/Patterns/files/MessageEventToParent.json
@@ -11,6 +11,8 @@
             "Task_F"
         ],
         "output": {
+            "email": "admin@example.com",
+            "login": "ADMIN",
             "fullName": "admin user",
             "status": {
                 "name": "COMPLETED",

--- a/tests/unit/ProcessMaker/Nayra/Bpmn/DataStoreTest.php
+++ b/tests/unit/ProcessMaker/Nayra/Bpmn/DataStoreTest.php
@@ -35,4 +35,209 @@ class DataStoreTest extends EngineTestCase
         //Assertion: the data store should have a non initialized item subject
         $this->assertNull($dataStore->getItemSubject());
     }
+
+    /**
+     * Tests the setDotData function with various scenarios
+     */
+    public function testSetDotData()
+    {
+        $dataStore = $this->repository->createDataStore();
+
+        // Test simple dot notation
+        $dataStore->setDotData('user.name', 'John Doe');
+        $userData = $dataStore->getData('user');
+        $this->assertEquals('John Doe', $userData['name']);
+
+        // Test nested dot notation
+        $dataStore->setDotData('user.profile.email', 'john@example.com');
+        $userData = $dataStore->getData('user');
+        $this->assertEquals('john@example.com', $userData['profile']['email']);
+
+        // Test deeply nested structure
+        $dataStore->setDotData('company.departments.engineering.team.lead', 'Jane Smith');
+        $companyData = $dataStore->getData('company');
+        $this->assertEquals('Jane Smith', $companyData['departments']['engineering']['team']['lead']);
+
+        // Test numeric keys
+        $dataStore->setDotData('items.0.name', 'First Item');
+        $dataStore->setDotData('items.1.name', 'Second Item');
+        $itemsData = $dataStore->getData('items');
+        $this->assertEquals('First Item', $itemsData[0]['name']);
+        $this->assertEquals('Second Item', $itemsData[1]['name']);
+
+        // Test numeric final key (to cover the is_numeric check for finalKey)
+        $dataStore->setDotData('scores.0', 100);
+        $dataStore->setDotData('scores.1', 200);
+        $scoresData = $dataStore->getData('scores');
+        $this->assertEquals(100, $scoresData[0]);
+        $this->assertEquals(200, $scoresData[1]);
+
+        // Test overwriting existing values
+        $dataStore->setDotData('user.name', 'Jane Doe');
+        $userData = $dataStore->getData('user');
+        $this->assertEquals('Jane Doe', $userData['name']);
+
+        // Test setting complex values
+        $complexValue = ['type' => 'admin', 'permissions' => ['read', 'write']];
+        $dataStore->setDotData('user.role', $complexValue);
+        $userData = $dataStore->getData('user');
+        $this->assertEquals($complexValue, $userData['role']);
+
+        // Test setting null values
+        $dataStore->setDotData('user.middleName', null);
+        $userData = $dataStore->getData('user');
+        $this->assertNull($userData['middleName']);
+
+        // Test setting boolean values
+        $dataStore->setDotData('user.active', true);
+        $userData = $dataStore->getData('user');
+        $this->assertTrue($userData['active']);
+
+        // Test setting numeric values
+        $dataStore->setDotData('user.age', 30);
+        $userData = $dataStore->getData('user');
+        $this->assertEquals(30, $userData['age']);
+
+        // Test that the method returns the data store instance for chaining
+        $result = $dataStore->setDotData('test.chain', 'value');
+        $this->assertSame($dataStore, $result);
+
+        // Verify the complete data structure
+        $expectedData = [
+            'user' => [
+                'name' => 'Jane Doe',
+                'profile' => [
+                    'email' => 'john@example.com'
+                ],
+                'role' => [
+                    'type' => 'admin',
+                    'permissions' => ['read', 'write']
+                ],
+                'middleName' => null,
+                'active' => true,
+                'age' => 30
+            ],
+            'company' => [
+                'departments' => [
+                    'engineering' => [
+                        'team' => [
+                            'lead' => 'Jane Smith'
+                        ]
+                    ]
+                ]
+            ],
+            'items' => [
+                0 => [
+                    'name' => 'First Item'
+                ],
+                1 => [
+                    'name' => 'Second Item'
+                ]
+            ],
+            'scores' => [
+                0 => 100,
+                1 => 200
+            ],
+            'test' => [
+                'chain' => 'value'
+            ]
+        ];
+
+        $this->assertEquals($expectedData, $dataStore->getData());
+    }
+
+    /**
+     * Tests the getDotData function with various scenarios
+     */
+    public function testGetDotData()
+    {
+        $dataStore = $this->repository->createDataStore();
+
+        // Set up test data using setDotData
+        $dataStore->setDotData('user.name', 'John Doe');
+        $dataStore->setDotData('user.profile.email', 'john@example.com');
+        $dataStore->setDotData('user.profile.age', 30);
+        $dataStore->setDotData('user.active', true);
+        $dataStore->setDotData('user.role', ['type' => 'admin', 'permissions' => ['read', 'write']]);
+        $dataStore->setDotData('company.departments.engineering.team.lead', 'Jane Smith');
+        $dataStore->setDotData('items.0.name', 'First Item');
+        $dataStore->setDotData('items.1.name', 'Second Item');
+        $dataStore->setDotData('scores.0', 100);
+        $dataStore->setDotData('scores.1', 200);
+        $dataStore->setDotData('user.middleName', null);
+
+        // Test simple dot notation retrieval
+        $this->assertEquals('John Doe', $dataStore->getDotData('user.name'));
+        $this->assertEquals('john@example.com', $dataStore->getDotData('user.profile.email'));
+        $this->assertEquals(30, $dataStore->getDotData('user.profile.age'));
+        $this->assertTrue($dataStore->getDotData('user.active'));
+
+        // Test nested dot notation retrieval
+        $this->assertEquals('Jane Smith', $dataStore->getDotData('company.departments.engineering.team.lead'));
+
+        // Test numeric keys
+        $this->assertEquals('First Item', $dataStore->getDotData('items.0.name'));
+        $this->assertEquals('Second Item', $dataStore->getDotData('items.1.name'));
+
+        // Test numeric final keys
+        $this->assertEquals(100, $dataStore->getDotData('scores.0'));
+        $this->assertEquals(200, $dataStore->getDotData('scores.1'));
+
+        // Test complex values
+        $expectedRole = ['type' => 'admin', 'permissions' => ['read', 'write']];
+        $this->assertEquals($expectedRole, $dataStore->getDotData('user.role'));
+
+        // Test null values
+        $this->assertNull($dataStore->getDotData('user.middleName'));
+
+        // Test non-existent paths with default values
+        $this->assertNull($dataStore->getDotData('non.existent.path'));
+        $this->assertEquals('default', $dataStore->getDotData('non.existent.path', 'default'));
+        $this->assertEquals('fallback', $dataStore->getDotData('user.nonExistent', 'fallback'));
+
+        // Test partial path that doesn't exist
+        $this->assertNull($dataStore->getDotData('user.profile.nonExistent'));
+        $this->assertEquals('not found', $dataStore->getDotData('user.profile.nonExistent', 'not found'));
+
+        // Test deeply nested non-existent path
+        $this->assertNull($dataStore->getDotData('company.departments.marketing.team.lead'));
+        $this->assertEquals('no lead', $dataStore->getDotData('company.departments.marketing.team.lead', 'no lead'));
+
+        // Test numeric key that doesn't exist
+        $this->assertNull($dataStore->getDotData('items.2.name'));
+        $this->assertEquals('missing', $dataStore->getDotData('items.2.name', 'missing'));
+
+        // Test empty path
+        $this->assertNull($dataStore->getDotData(''));
+        $this->assertEquals('empty', $dataStore->getDotData('', 'empty'));
+
+        // Test single key that exists (returns the entire user array)
+        $userData = $dataStore->getDotData('user');
+        $this->assertIsArray($userData);
+        $this->assertEquals('John Doe', $userData['name']);
+        $this->assertEquals('john@example.com', $userData['profile']['email']);
+        $this->assertEquals(30, $userData['profile']['age']);
+        $this->assertTrue($userData['active']);
+        $this->assertNull($userData['middleName']);
+
+        // Test single key that doesn't exist
+        $this->assertNull($dataStore->getDotData('nonexistent'));
+        $this->assertEquals('not found', $dataStore->getDotData('nonexistent', 'not found'));
+
+        // Test boolean false value
+        $dataStore->setDotData('user.disabled', false);
+        $this->assertFalse($dataStore->getDotData('user.disabled'));
+
+        // Test zero value
+        $dataStore->setDotData('user.score', 0);
+        $this->assertEquals(0, $dataStore->getDotData('user.score'));
+
+        // Test empty string
+        $dataStore->setDotData('user.description', '');
+        $this->assertEquals('', $dataStore->getDotData('user.description'));
+
+        // Test empty array
+        $dataStore->setDotData('user.tags', []);
+        $this->assertEquals([], $dataStore->getDotData('user.tags'));
+    }
 }


### PR DESCRIPTION
## Improve Message Catch and Throw Events Elements to configure the Message Payload

Send data from sub-process using `Intermediate Message Event C` to parent process on Boundary Event at `Call-Activity A`.

<img width="652" height="548" alt="image" src="https://github.com/user-attachments/assets/3d81f146-f76a-4f6d-b5f6-5691ee5f7349" />

## Related ticket
- https://processmaker.atlassian.net/browse/FOUR-26839

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds message payload mapping from throw events using data input associations (with transformations/assignments), introduces dot-notation get/set on data store, updates BPMN parsing/mappings, and adds tests.
> 
> - **Engine/BPMN**:
>   - **Message Payload Mapping**: Implement `Assignment` and `DataInputAssociation` with support for `transformation` and `assignments`, and wire into `MessageEventDefinition::execute` to build payload from throw event inputs and write to target instance via `DataStore`.
>   - **Events**: Initialize and expose `dataInput`, `dataInputAssociation`, and `eventDefinitions` via properties in `IntermediateThrowEvent` and `EndEvent` (fixes recursive accessor and initializes collections).
>   - **Data Store**: Add `getDotData` and `setDotData` in `DataStoreTrait` for nested access; declare in `DataStoreInterface`.
> - **Contracts**:
>   - Add constants to `AssignmentInterface`; update `DataAssociationInterface` signatures (`getSource`, `getAssignments`) and return types.
>   - Extend `DataInputAssociationInterface` with property constants; extend `EventInterface` with `dataInput`, `inputSet`, `dataInputAssociation` properties; add `FormalExpressionInterface::__invoke`.
> - **Storage/Parsing**:
>   - Extend `BpmnDocument` mappings to parse `dataInputAssociation`, `targetRef`, `sourceRef`, `transformation`, and nested `assignment` for `intermediateThrowEvent`.
>   - Add repository factories for `DataInputAssociation` and `Assignment`.
> - **Tests**:
>   - New BPMN/JSON fixture `tests/Feature/Patterns/files/MessageEventToParent.*` validating message data propagation to parent.
>   - Unit tests for `DataStore` dot-notation get/set.
> - **CI**:
>   - Workflow: replace coverage listing with `./check_coverage.php` in SonarQube job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 282cab046a3e45f98f5cdc0ffaed1e6202074a04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->