### PR TITLE
FOUR-26911 Implement Catch Event Message Mapping

### DIFF
--- a/src/ProcessMaker/Nayra/Bpmn/CatchEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/CatchEventTrait.php
@@ -48,16 +48,6 @@ trait CatchEventTrait
         return $this->getProperty(CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_ASSOCIATION);
     }
 
-    public function getDataOutput()
-    {
-        return $this->getProperty(CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT);
-    }
-
-    public function getDataOutputSet()
-    {
-        return $this->getProperty(CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_SET);
-    }
-
     /**
      * Register catch events.
      *

--- a/src/ProcessMaker/Nayra/Bpmn/CatchEventTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/CatchEventTrait.php
@@ -30,6 +30,7 @@ trait CatchEventTrait
     {
         $this->setProperty(CatchEventInterface::BPMN_PROPERTY_EVENT_DEFINITIONS, new Collection);
         $this->setProperty(CatchEventInterface::BPMN_PROPERTY_PARALLEL_MULTIPLE, false);
+        $this->setProperty(CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_ASSOCIATION, new Collection);
     }
 
     /**
@@ -40,6 +41,21 @@ trait CatchEventTrait
     public function getEventDefinitions()
     {
         return $this->getProperty(CatchEventInterface::BPMN_PROPERTY_EVENT_DEFINITIONS);
+    }
+
+    public function getDataOutputAssociations()
+    {
+        return $this->getProperty(CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_ASSOCIATION);
+    }
+
+    public function getDataOutput()
+    {
+        return $this->getProperty(CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT);
+    }
+
+    public function getDataOutputSet()
+    {
+        return $this->getProperty(CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_SET);
     }
 
     /**

--- a/src/ProcessMaker/Nayra/Bpmn/DataOutputAssociation.php
+++ b/src/ProcessMaker/Nayra/Bpmn/DataOutputAssociation.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ProcessMaker\Nayra\Bpmn;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\DataOutputAssociationInterface;
+
+/**
+ * DataOutputAssociation class for handling data output associations in BPMN processes
+ */
+class DataOutputAssociation implements DataOutputAssociationInterface
+{
+    use BaseTrait;
+
+    protected function initDataOutputAssociation()
+    {
+        $this->properties[static::BPMN_PROPERTY_ASSIGNMENT] = new Collection;
+    }
+
+    public function getSource()
+    {
+        return $this->getProperty(static::BPMN_PROPERTY_SOURCES_REF);
+    }
+
+    public function getTarget()
+    {
+        return $this->getProperty(static::BPMN_PROPERTY_TARGET_REF);
+    }
+
+    public function getTransformation()
+    {
+        return $this->getProperty(static::BPMN_PROPERTY_TRANSFORMATION);
+    }
+
+    public function getAssignments()
+    {
+        return $this->getProperty(static::BPMN_PROPERTY_ASSIGNMENT);
+    }
+}

--- a/src/ProcessMaker/Nayra/Bpmn/DataStoreTrait.php
+++ b/src/ProcessMaker/Nayra/Bpmn/DataStoreTrait.php
@@ -113,21 +113,21 @@ trait DataStoreTrait
     {
         $keys = explode('.', $path);
         $current = $this->data;
-        
+
         // Navigate through the path
         foreach ($keys as $key) {
             // Handle numeric keys for arrays
             if (is_numeric($key)) {
                 $key = (int) $key;
             }
-            
+
             if (!isset($current[$key])) {
                 return $default;
             }
-            
+
             $current = $current[$key];
         }
-        
+
         return $current;
     }
 
@@ -142,31 +142,34 @@ trait DataStoreTrait
     public function setDotData($path, $value)
     {
         $keys = explode('.', $path);
+        $firstKey = $keys[0];
         $current = &$this->data;
-        
+
         // Navigate to the parent of the target key
         for ($i = 0; $i < count($keys) - 1; $i++) {
             $key = $keys[$i];
-            
+
             // Handle numeric keys for arrays
             if (is_numeric($key)) {
                 $key = (int) $key;
             }
-            
+
             if (!isset($current[$key]) || !is_array($current[$key])) {
                 $current[$key] = [];
             }
             $current = &$current[$key];
         }
-        
+
         // Set the final value
         $finalKey = $keys[count($keys) - 1];
         if (is_numeric($finalKey)) {
             $finalKey = (int) $finalKey;
         }
-        
+
         $current[$finalKey] = $value;
-        
+        // Keep compatibility with putData method (required by PM Core)
+        $this->putData($firstKey, $this->data[$firstKey]);
+
         return $this;
     }
 }

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
@@ -3,6 +3,9 @@
 namespace ProcessMaker\Nayra\Bpmn\Models;
 
 use ProcessMaker\Nayra\Bpmn\EventDefinitionTrait;
+use ProcessMaker\Nayra\Contracts\Bpmn\CatchEventInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\CollectionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\DataStoreInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowNodeInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\MessageEventDefinitionInterface;
@@ -90,47 +93,78 @@ class MessageEventDefinition implements MessageEventDefinitionInterface
     public function execute(EventDefinitionInterface $event, FlowNodeInterface $target, ExecutionInstanceInterface $instance = null, TokenInterface $token = null)
     {
         $throwEvent = $token->getOwnerElement();
-        $this->evaluateMessagePayload($throwEvent, $token, $instance);
+        $this->executeMessageMapping($throwEvent, $target, $instance, $token);
         return $this;
+    }
+
+    /**
+     * Map a message payload from a ThrowEvent through an optional CatchEvent mapping
+     * into the instance data store.
+     *
+     * @param ThrowEventInterface $throwEvent
+     * @param CatchEventInterface $catchEvent
+     * @param ExecutionInstanceInterface $instance
+     * @param TokenInterface $token
+     *
+     * @return void
+     */
+    private function executeMessageMapping(ThrowEventInterface $throwEvent, CatchEventInterface $catchEvent, ExecutionInstanceInterface $instance, TokenInterface $token): void
+    {
+        $sourceMaps   = $throwEvent->getDataInputAssociations();
+        $targetMaps   = $catchEvent->getDataOutputAssociations();
+        $instanceStore = $instance->getDataStore();
+
+        // Source of data is the token's instance store if present; otherwise a fresh store.
+        $sourceStore = $token->getInstance()?->getDataStore() ?? new DataStore();
+
+        // If target mappings exist we stage into a buffer; otherwise write straight to the instance store.
+        $bufferStore = !count($targetMaps) ? $instanceStore : new DataStore();
+
+        // 1) Source mappings: source → buffer/instance
+        $this->evaluateMessagePayload($sourceMaps, $sourceStore, $bufferStore);
+
+        // 2) Optional target mappings: buffer → instance
+        if (count($targetMaps)) {
+            $this->evaluateMessagePayload($targetMaps, $bufferStore, $instanceStore);
+        }
     }
 
     /**
      * Evaluate the message payload
      *
-     * @param ThrowEventInterface $throwEvent
-     * @param TokenInterface $token
-     * @param ExecutionInstanceInterface $targetInstance
+     * @param CollectionInterface $associations
+     * @param DataStoreInterface $sourceStore
+     * @param DataStoreInterface $targetStore
+     *
      * @return void
      */
-    private function evaluateMessagePayload(ThrowEventInterface $throwEvent, TokenInterface $token, ExecutionInstanceInterface $targetInstance)
+    private function evaluateMessagePayload(CollectionInterface $associations, DataStoreInterface $sourceStore, DataStoreInterface $targetStore): void
     {
-        // Initialize message payload
-        $payload = [];
-        $associations = $throwEvent->getDataInputAssociations();
-        // Get data from source token instance or empty one if not found
-        $sourceDataStore = $token->getInstance()?->getDataStore() ?? new DataStore();
+        $assignments = [];
 
-        // Associate data inputs to message payload
         foreach ($associations as $association) {
-            $data = $sourceDataStore->getData();
             $source = $association->getSource();
             $target = $association->getTarget();
 
-            // Add reference to source
             $hasSource = $source && $source->getName();
             $hasTarget = $target && $target->getName();
-            $data['sourceRef'] = $hasSource ? $sourceDataStore->getDotData($source->getName()) : null;
 
-            // Apply transformation
-            $this->applyTransformation($association, $data, $payload, $hasTarget, $hasSource);
+            // Base data always starts from full source store
+            $data = $sourceStore->getData();
 
-            // Evaluate assignments
-            $this->evaluateAssignments($association, $data, $payload);
+            // Optionally add a direct reference to the source value
+            if ($hasSource) {
+                $data['sourceRef'] = $sourceStore->getDotData($source->getName());
+            }
+
+            // Transformation and assignments build up the assignments list
+            $this->applyTransformation($association, $data, $assignments, $hasTarget, $hasSource);
+            $this->evaluateAssignments($association, $data, $assignments);
         }
-        // Update data into target $instance
-        $dataStore = $targetInstance->getDataStore();
-        foreach ($payload as $load) {
-            $dataStore->setDotData($load['key'], $load['value']);
+
+        // Flush all assignments into target store
+        foreach ($assignments as $assignment) {
+            $targetStore->setDotData($assignment['key'], $assignment['value']);
         }
     }
 

--- a/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
+++ b/src/ProcessMaker/Nayra/Bpmn/Models/MessageEventDefinition.php
@@ -110,22 +110,22 @@ class MessageEventDefinition implements MessageEventDefinitionInterface
      */
     private function executeMessageMapping(ThrowEventInterface $throwEvent, CatchEventInterface $catchEvent, ExecutionInstanceInterface $instance, TokenInterface $token): void
     {
-        $sourceMaps   = $throwEvent->getDataInputAssociations();
-        $targetMaps   = $catchEvent->getDataOutputAssociations();
-        $instanceStore = $instance->getDataStore();
+        $sourceMaps = $throwEvent->getDataInputAssociations();
+        $targetMaps = $catchEvent->getDataOutputAssociations();
+        $targetStore = $instance->getDataStore();
 
         // Source of data is the token's instance store if present; otherwise a fresh store.
         $sourceStore = $token->getInstance()?->getDataStore() ?? new DataStore();
 
         // If target mappings exist we stage into a buffer; otherwise write straight to the instance store.
-        $bufferStore = !count($targetMaps) ? $instanceStore : new DataStore();
+        $bufferStore = !count($targetMaps) ? $targetStore : new DataStore();
 
         // 1) Source mappings: source → buffer/instance
         $this->evaluateMessagePayload($sourceMaps, $sourceStore, $bufferStore);
 
         // 2) Optional target mappings: buffer → instance
         if (count($targetMaps)) {
-            $this->evaluateMessagePayload($targetMaps, $bufferStore, $instanceStore);
+            $this->evaluateMessagePayload($targetMaps, $bufferStore, $targetStore);
         }
     }
 

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/CatchEventInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/CatchEventInterface.php
@@ -16,6 +16,12 @@ interface CatchEventInterface extends EventInterface
 
     const EVENT_CATCH_TOKEN_ARRIVES = 'CatchEventTokenArrives';
 
+    const BPMN_PROPERTY_DATA_OUTPUT = 'dataOutput';
+
+    const BPMN_PROPERTY_DATA_OUTPUT_SET = 'outputSet';
+
+    const BPMN_PROPERTY_DATA_OUTPUT_ASSOCIATION = 'dataOutputAssociation';
+
     /**
      * Get EventDefinitions that are triggers expected for a catch Event.
      *
@@ -57,4 +63,11 @@ interface CatchEventInterface extends EventInterface
      * @return StateInterface
      */
     public function getActiveState();
+
+    /**
+     * Get the data output associations.
+     *
+     * @return DataOutputAssociationInterface[]
+     */
+    public function getDataOutputAssociations();
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/CollectionInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/CollectionInterface.php
@@ -3,11 +3,12 @@
 namespace ProcessMaker\Nayra\Contracts\Bpmn;
 
 use SeekableIterator;
+use Countable;
 
 /**
  * CollectionInterface
  */
-interface CollectionInterface extends SeekableIterator
+interface CollectionInterface extends SeekableIterator, Countable
 {
     /**
      * Count the elements of the collection.

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/DataAssociationInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/DataAssociationInterface.php
@@ -7,6 +7,11 @@ namespace ProcessMaker\Nayra\Contracts\Bpmn;
  */
 interface DataAssociationInterface extends EntityInterface
 {
+    const BPMN_PROPERTY_ASSIGNMENT = 'assignment';
+    const BPMN_PROPERTY_SOURCES_REF = 'sourceRef';
+    const BPMN_PROPERTY_TARGET_REF = 'targetRef';
+    const BPMN_PROPERTY_TRANSFORMATION = 'transformation';
+
     /**
      * Get the source of the data association.
      *

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/DataOutputAssociationInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/DataOutputAssociationInterface.php
@@ -7,4 +7,5 @@ namespace ProcessMaker\Nayra\Contracts\Bpmn;
  */
 interface DataOutputAssociationInterface extends DataAssociationInterface
 {
+    
 }

--- a/src/ProcessMaker/Nayra/Contracts/Bpmn/ThrowEventInterface.php
+++ b/src/ProcessMaker/Nayra/Contracts/Bpmn/ThrowEventInterface.php
@@ -18,6 +18,12 @@ interface ThrowEventInterface extends EventInterface
 
     const EVENT_THROW_TOKEN_CONSUMED = 'ThrowEventTokenConsumed';
 
+    const BPMN_PROPERTY_DATA_INPUT = 'dataInput';
+
+    const BPMN_PROPERTY_DATA_INPUT_SET = 'inputSet';
+
+    const BPMN_PROPERTY_DATA_INPUT_ASSOCIATION = 'dataInputAssociation';
+
     /**
      * Get Data Inputs for the throw Event.
      *

--- a/src/ProcessMaker/Nayra/RepositoryTrait.php
+++ b/src/ProcessMaker/Nayra/RepositoryTrait.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Nayra;
 use InvalidArgumentException;
 use ProcessMaker\Nayra\Bpmn\Assignment;
 use ProcessMaker\Nayra\Bpmn\DataInputAssociation;
+use ProcessMaker\Nayra\Bpmn\DataOutputAssociation;
 use ProcessMaker\Nayra\Bpmn\Lane;
 use ProcessMaker\Nayra\Bpmn\LaneSet;
 use ProcessMaker\Nayra\Bpmn\Models\Activity;
@@ -492,5 +493,10 @@ trait RepositoryTrait
     public function createAssignment()
     {
         return new Assignment();
+    }
+
+    public function createDataOutputAssociation()
+    {
+        return new DataOutputAssociation();
     }
 }

--- a/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
+++ b/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
@@ -712,7 +712,7 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
                 ? $element->getBpmnElementInstance()
                 : null
             );
-        if ($this->bpmnElements[$id] === null && $element === null) {
+        if ($this->bpmnElements[$id] === null && empty($element)) {
             throw new ElementNotFoundException($id);
         }
 

--- a/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
+++ b/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
@@ -712,7 +712,7 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
                 ? $element->getBpmnElementInstance()
                 : null
             );
-        if ($this->bpmnElements[$id] === null) {
+        if ($this->bpmnElements[$id] === null && $element === null) {
             throw new ElementNotFoundException($id);
         }
 

--- a/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
+++ b/src/ProcessMaker/Nayra/Storage/BpmnDocument.php
@@ -14,6 +14,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\CollaborationInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ConditionalEventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\DataInputAssociationInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\DataInputInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\DataOutputAssociationInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\DataOutputInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\DataStoreInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EndEventInterface;
@@ -54,6 +55,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\SignalInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\StandardLoopCharacteristicsInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\StartEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TerminateEventDefinitionInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\ThrowEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TimerEventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 use ProcessMaker\Nayra\Contracts\RepositoryInterface;
@@ -119,6 +121,9 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
                     FlowNodeInterface::BPMN_PROPERTY_INCOMING => ['n', [self::BPMN_MODEL, FlowNodeInterface::BPMN_PROPERTY_INCOMING]],
                     FlowNodeInterface::BPMN_PROPERTY_OUTGOING => ['n', [self::BPMN_MODEL, FlowNodeInterface::BPMN_PROPERTY_OUTGOING]],
                     EndEventInterface::BPMN_PROPERTY_EVENT_DEFINITIONS => ['n', EventDefinitionInterface::class],
+                    IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT => ['n', [self::BPMN_MODEL, IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT]],
+                    IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_SET => ['1', [self::BPMN_MODEL, IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_SET]],
+                    IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION => ['n', [self::BPMN_MODEL, IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION]],
                 ],
             ],
             'task' => [
@@ -378,7 +383,7 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
                     IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION => ['n', [self::BPMN_MODEL, IntermediateThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION]],
                 ],
             ],
-            'dataInputAssociation' => [
+            ThrowEventInterface::BPMN_PROPERTY_DATA_INPUT_ASSOCIATION => [
                 DataInputAssociationInterface::class,
                 [
                     DataInputAssociationInterface::BPMN_PROPERTY_TARGET_REF => ['1', [self::BPMN_MODEL, DataInputAssociationInterface::BPMN_PROPERTY_TARGET_REF]],
@@ -412,6 +417,15 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
                 FormalExpressionInterface::class,
                 [
                     FormalExpressionInterface::BPMN_PROPERTY_BODY => ['1', self::DOM_ELEMENT_BODY],
+                ],
+            ],
+            CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_ASSOCIATION => [
+                DataOutputAssociationInterface::class,
+                [
+                    DataOutputAssociationInterface::BPMN_PROPERTY_TARGET_REF => ['1', [self::BPMN_MODEL, DataOutputAssociationInterface::BPMN_PROPERTY_TARGET_REF]],
+                    DataOutputAssociationInterface::BPMN_PROPERTY_SOURCES_REF => ['1', [self::BPMN_MODEL, DataOutputAssociationInterface::BPMN_PROPERTY_SOURCES_REF]],
+                    DataOutputAssociationInterface::BPMN_PROPERTY_ASSIGNMENT => ['n', [self::BPMN_MODEL, DataOutputAssociationInterface::BPMN_PROPERTY_ASSIGNMENT]],
+                    DataOutputAssociationInterface::BPMN_PROPERTY_TRANSFORMATION => ['1', [self::BPMN_MODEL, DataOutputAssociationInterface::BPMN_PROPERTY_TRANSFORMATION]],
                 ],
             ],
             'signalEventDefinition' => [
@@ -455,6 +469,9 @@ class BpmnDocument extends DOMDocument implements BpmnDocumentInterface
                     BoundaryEventInterface::BPMN_PROPERTY_ATTACHED_TO => ['1', [self::BPMN_MODEL, BoundaryEventInterface::BPMN_PROPERTY_ATTACHED_TO_REF]],
                     CatchEventInterface::BPMN_PROPERTY_EVENT_DEFINITIONS => ['n', EventDefinitionInterface::class],
                     FlowNodeInterface::BPMN_PROPERTY_OUTGOING => ['n', [self::BPMN_MODEL, FlowNodeInterface::BPMN_PROPERTY_OUTGOING]],
+                    CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT => ['n', [self::BPMN_MODEL, CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT]],
+                    CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_SET => ['1', [self::BPMN_MODEL, CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_SET]],
+                    CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_ASSOCIATION => ['n', [self::BPMN_MODEL, CatchEventInterface::BPMN_PROPERTY_DATA_OUTPUT_ASSOCIATION]],
                 ],
             ],
             'multiInstanceLoopCharacteristics' => [

--- a/tests/Feature/Patterns/files/MessageEventToParentCatchMapped.bpmn
+++ b/tests/Feature/Patterns/files/MessageEventToParentCatchMapped.bpmn
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn"
+    >
+    <collaboration id="Collaboration_0utf0sd">
+        <participant id="Participant_1f4jbtu" name="main" processRef="Process_1" />
+        <participant id="Participant_0qod0gz" name="sub-process" processRef="Process_1gn8a5z" />
+    </collaboration>
+    <dataStore id="ds_email" name="user.email"/>
+    <message id="Message_0z3vg33" name="Message_0z3vg33" />
+    <process id="Process_1" isExecutable="false">
+        <startEvent id="StartEvent">
+            <outgoing>SequenceFlow_0h21x7r</outgoing>
+        </startEvent>
+        <endEvent id="Event_0tpzg6j">
+            <incoming>Flow_148wtcr</incoming>
+        </endEvent>
+        <callActivity id="Task_A" name="A" calledElement="Process_1gn8a5z">
+            <incoming>SequenceFlow_0h21x7r</incoming>
+            <outgoing>Flow_1r89qx6</outgoing>
+        </callActivity>
+        <scriptTask id="Task_F" name="F">
+            <incoming>Flow_1r89qx6</incoming>
+            <outgoing>Flow_148wtcr</outgoing>
+        </scriptTask>
+        <scriptTask id="Task_D" name="D">
+            <incoming>Flow_0azzp4i</incoming>
+        </scriptTask>
+        <sequenceFlow id="Flow_148wtcr" sourceRef="Task_F" targetRef="Event_0tpzg6j" />
+        <sequenceFlow id="SequenceFlow_0h21x7r" sourceRef="StartEvent" targetRef="Task_A" />
+        <sequenceFlow id="Flow_1r89qx6" sourceRef="Task_A" targetRef="Task_F" />
+        <sequenceFlow id="Flow_0azzp4i" sourceRef="Event_A" targetRef="Task_D" />
+        <boundaryEvent id="Event_A" cancelActivity="false" attachedToRef="Task_A">
+            <outgoing>Flow_0azzp4i</outgoing>
+            <!-- Do extra data mapping-->
+            <dataOutput id="ds_client" name="client"/>
+            <dataOutput id="ds_status" name="status"/>
+            <dataOutputAssociation>
+                <targetRef>ds_status</targetRef>
+                <assignment>
+                    <from>status</from>
+                    <to>status</to>
+                </assignment>
+            </dataOutputAssociation>
+            <dataOutputAssociation>
+                <targetRef>ds_client</targetRef>
+                <assignment>
+                    <from><![CDATA[["email" => $data['email'], "login" => $data['login'], "fullName" => $data['fullName']]]]></from>
+                    <to>client</to>
+                </assignment>
+            </dataOutputAssociation>
+            <outputSet>
+                <dataOutputRefs>ds_client</dataOutputRefs>
+                <dataOutputRefs>ds_status</dataOutputRefs>
+            </outputSet>
+            <messageEventDefinition id="MessageEventDefinition_0z3vg33" messageRef="Message_0z3vg33" />
+        </boundaryEvent>
+    </process>
+    <process id="Process_1gn8a5z">
+        <startEvent id="Event_1jwnr1y">
+            <outgoing>Flow_1a3yzli</outgoing>
+        </startEvent>
+        <endEvent id="Event_19thta4">
+            <incoming>Flow_09pcqxs</incoming>
+        </endEvent>
+        <scriptTask id="Task_B" name="B" scriptFormat="application/x-betsy">
+            <incoming>Flow_1a3yzli</incoming>
+            <outgoing>Flow_0ntd3ys</outgoing>
+            <script><![CDATA[return ['user' => ['firstname' => 'admin', 'lastname' => 'user', 'username' => 'admin', 'email' => 'admin@example.com']];]]></script>
+        </scriptTask>
+        <scriptTask id="Task_E" name="E" scriptFormat="application/x-betsy">
+            <incoming>Flow_1r1agfn</incoming>
+            <outgoing>Flow_09pcqxs</outgoing>
+            <script><![CDATA[
+                // clear sub process data
+                $data = []; return [];
+            ]]></script>
+        </scriptTask>
+        <sequenceFlow id="Flow_1a3yzli" sourceRef="Event_1jwnr1y" targetRef="Task_B" />
+        <sequenceFlow id="Flow_09pcqxs" sourceRef="Task_E" targetRef="Event_19thta4" />
+        <sequenceFlow id="Flow_0ntd3ys" sourceRef="Task_B" targetRef="Event_C" />
+        <sequenceFlow id="Flow_1r1agfn" sourceRef="Event_C" targetRef="Task_E" />
+        <intermediateThrowEvent id="Event_C" name="C">
+            <incoming>Flow_0ntd3ys</incoming>
+            <outgoing>Flow_1r1agfn</outgoing>
+            <!-- Define the input of the message -->
+            <dataInput id="din_login" name="login" /> <!-- N -->
+            <dataInput id="din_status" name="status" /> <!-- N -->
+            <dataInput id="din_email" name="email" /> <!-- N -->
+            <!-- Simple Data association -->
+            <dataInputAssociation> <!-- N -->
+                <targetRef>din_email</targetRef>
+                <sourceRef>ds_email</sourceRef>
+            </dataInputAssociation>
+            <!-- Data association with transformation and assignment -->
+            <dataInputAssociation> <!-- N -->
+                <targetRef>din_login</targetRef>
+                <transformation><![CDATA[ strtoupper("{$data['user']['username']}") ]]></transformation>
+                <assignment> <!-- N -->
+                    <!-- FEEL expression mapping -->
+                    <from><![CDATA[ "{$data['user']['firstname']} {$data['user']['lastname']}" ]]></from>
+                    <to>fullName</to>
+                </assignment>
+            </dataInputAssociation>
+            <!-- Data association with dot notation assignment -->
+            <dataInputAssociation> <!-- N -->
+                <targetRef>din_status</targetRef>
+                <assignment> <!-- N -->
+                    <!-- FEEL expression mapping -->
+                    <from><![CDATA[ "COMPLETED" ]]></from>
+                    <to>status.name</to>
+                </assignment>
+                <assignment> <!-- N -->
+                    <!-- FEEL expression mapping -->
+                    <from><![CDATA[ "The task has been completed" ]]></from>
+                    <to>status.description</to>
+                </assignment>
+            </dataInputAssociation>
+            <!-- InputSet definition -->
+            <inputSet> <!-- N -->
+                <dataInputRefs>din_email</dataInputRefs>
+                <dataInputRefs>din_login</dataInputRefs>
+                <dataInputRefs>din_status</dataInputRefs>
+            </inputSet>
+            <!-- Message Event Definition -->
+            <messageEventDefinition id="MessageEventDefinition_1ihpiso" messageRef="Message_0z3vg33" />
+        </intermediateThrowEvent>
+    </process>
+    <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+        <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Collaboration_0utf0sd">
+            <bpmndi:BPMNShape id="Participant_1f4jbtu_di" bpmnElement="Participant_1f4jbtu"
+                isHorizontal="true">
+                <omgdc:Bounds x="160" y="60" width="630" height="250" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0tpzg6j_di" bpmnElement="Event_0tpzg6j">
+                <omgdc:Bounds x="722" y="232" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="StartEvent_di" bpmnElement="StartEvent">
+                <omgdc:Bounds x="212" y="232" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <omgdc:Bounds x="124" y="275" width="73" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1nv96va_di" bpmnElement="Task_A">
+                <omgdc:Bounds x="338" y="210" width="100" height="80" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1jrjxm3_di" bpmnElement="Task_F">
+                <omgdc:Bounds x="533" y="210" width="100" height="80" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1bz9cme_di" bpmnElement="Task_D">
+                <omgdc:Bounds x="460" y="90" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0mt9bns_di" bpmnElement="Event_A">
+                <omgdc:Bounds x="370" y="192" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_148wtcr_di" bpmnElement="Flow_148wtcr">
+                <omgdi:waypoint x="633" y="250" />
+                <omgdi:waypoint x="722" y="250" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="SequenceFlow_0h21x7r_di" bpmnElement="SequenceFlow_0h21x7r">
+                <omgdi:waypoint x="248" y="250" />
+                <omgdi:waypoint x="338" y="250" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1r89qx6_di" bpmnElement="Flow_1r89qx6">
+                <omgdi:waypoint x="438" y="250" />
+                <omgdi:waypoint x="533" y="250" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0azzp4i_di" bpmnElement="Flow_0azzp4i">
+                <omgdi:waypoint x="388" y="192" />
+                <omgdi:waypoint x="388" y="130" />
+                <omgdi:waypoint x="460" y="130" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Participant_0qod0gz_di" bpmnElement="Participant_0qod0gz"
+                isHorizontal="true">
+                <omgdc:Bounds x="160" y="340" width="630" height="250" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_1jwnr1y_di" bpmnElement="Event_1jwnr1y">
+                <omgdc:Bounds x="212" y="442" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_19thta4_di" bpmnElement="Event_19thta4">
+                <omgdc:Bounds x="722" y="442" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0ttojsf_di" bpmnElement="Task_B">
+                <omgdc:Bounds x="305" y="420" width="100" height="80" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0rxm6q1_di" bpmnElement="Task_E">
+                <omgdc:Bounds x="565" y="420" width="100" height="80" />
+                <bpmndi:BPMNLabel />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_12cu2ng_di" bpmnElement="Event_C">
+                <omgdc:Bounds x="467" y="442" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <omgdc:Bounds x="481" y="485" width="8" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_1a3yzli_di" bpmnElement="Flow_1a3yzli">
+                <omgdi:waypoint x="248" y="460" />
+                <omgdi:waypoint x="305" y="460" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_09pcqxs_di" bpmnElement="Flow_09pcqxs">
+                <omgdi:waypoint x="665" y="460" />
+                <omgdi:waypoint x="722" y="460" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0ntd3ys_di" bpmnElement="Flow_0ntd3ys">
+                <omgdi:waypoint x="405" y="460" />
+                <omgdi:waypoint x="467" y="460" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1r1agfn_di" bpmnElement="Flow_1r1agfn">
+                <omgdi:waypoint x="503" y="460" />
+                <omgdi:waypoint x="565" y="460" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/Feature/Patterns/files/MessageEventToParentCatchMapped.json
+++ b/tests/Feature/Patterns/files/MessageEventToParentCatchMapped.json
@@ -1,0 +1,25 @@
+[
+    {
+        "comment": "Message event sent multiple data inputs to parent",
+        "startEvent": "StartEvent",
+        "data": {
+        },
+        "result": [
+            "Task_B",
+            "Task_D",
+            "Task_E",
+            "Task_F"
+        ],
+        "output": {
+            "client": {
+                "email": "admin@example.com",
+                "login": "ADMIN",
+                "fullName": "admin user"
+            },
+            "status": {
+                "name": "COMPLETED",
+                "description": "The task has been completed"
+            }
+        }
+    }
+]


### PR DESCRIPTION
## Implement Catch Event Message Mapping
When message arrived to Boundary Event at `Call-Activity A`, its content is mapped using the DataOutput associations declared in the Boundary Catch Event.

<img width="652" height="548" alt="image" src="https://github.com/user-attachments/assets/3d81f146-f76a-4f6d-b5f6-5691ee5f7349" />

## Related ticket
- https://processmaker.atlassian.net/browse/FOUR-26911

